### PR TITLE
Implement force flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or use interactive mode (if required options are missing):
 - `--docker, -d`       Include Docker support
 - `--examples, -e`     Include example resources and tools
 - `--output, -o`       Output directory (default: project name)
-- `--foorce, -f`       Overwrite existing directory (**note: flag is currently `--foorce` due to a typo**)
+- `--force, -f`        Overwrite existing directory
 
 ### Test an MCP server
 

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -21,9 +21,9 @@ func main() {
 	// Add subcommands
 	rootCmd.AddCommand(commands.NewGenerateCmd())
 	rootCmd.AddCommand(commands.NewTestCmd())
-	// TODO: Add future commands 
+	// TODO: Add future commands
 
-	// Global flags 
+	// Global flags
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress output")
 

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -298,7 +298,7 @@ func validateOptions(opts *GenerateOptions) error {
 		return fmt.Errorf("invalid transport: %s, valid options are: %v", opts.Transport, validTransports)
 	}
 
-	// Set default outpyt directory if not provided
+	// Set default output directory if not provided
 	if opts.Output == "" {
 		opts.Output = opts.Name
 	}
@@ -330,9 +330,17 @@ func generateProject(opts *GenerateOptions) error {
 		Capabilities: opts.Capabilities,
 	}
 
-	// Check if the directory exists
-	if _, err := os.Stat(opts.Output); !os.IsNotExist(err) {
-		return fmt.Errorf("output directory %s already exists, use --force to overwrite", opts.Output)
+	// Check if the directory exists and handle the --force flag
+	if _, err := os.Stat(opts.Output); err == nil {
+		if opts.Force {
+			if err := os.RemoveAll(opts.Output); err != nil {
+				return fmt.Errorf("failed to remove existing directory: %w", err)
+			}
+		} else {
+			return fmt.Errorf("output directory %s already exists, use --force to overwrite", opts.Output)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to check output directory: %w", err)
 	}
 
 	// Create output directory
@@ -364,7 +372,7 @@ func generateProject(opts *GenerateOptions) error {
 	fmt.Printf("🚀 Next steps:\n")
 	fmt.Printf("   cd %s\n", opts.Output)
 
-	if opts.Language == "go" {
+	if opts.Language == "go" || opts.Language == "golang" {
 		fmt.Printf("   go mod tidy\n")
 		fmt.Printf("   go run cmd/%s/main.go\n", opts.Transport)
 	}


### PR DESCRIPTION
## Summary
- implement `--force` flag to allow overwriting output directory during project generation
- fix newline at end of `cmd/mcpcli/main.go`
- document `--force` flag in README
- show Go instructions when `--language` is `golang`

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882d9f71da4832f850f09826fd1350d