### PR TITLE
Fix invalid Go identifiers in scaffold templates

### DIFF
--- a/internal/generators/templates/go/stdio/internal/capabilities/capability.go.tmpl
+++ b/internal/generators/templates/go/stdio/internal/capabilities/capability.go.tmpl
@@ -3,15 +3,15 @@ package capabilities
 import "{{.ModuleName}}/pkg/mcp"
 
 // {{.Capability.Name}} capability
-type {{.Capability.Name }}Capability struct{}
+type {{.Capability.Name}}Capability struct{}
 
 // New{{.Capability.Name }}Capability creates a new {{.Capability.Name}} capability
-func New{{.Capability.Name }}Capability() *{{.Capability.Name }}Capability {
-	return &{{.Capability.Name }}Capability{}
+func New{{.Capability.Name}}Capability() *{{.Capability.Name}}Capability {
+        return &{{.Capability.Name}}Capability{}
 }
 
 // Enable executes the capability logic
-func (c *{{.Capability.Name }}Capability) Enable(req mcp.Request) mcp.Response {
+func (c *{{.Capability.Name}}Capability) Enable(req mcp.Request) mcp.Response {
 	// TODO: Implement capability logic for {{.Capability.Name}}
 	return mcp.Response{
 		Result: map[string]interface{}{

--- a/internal/generators/templates/go/stdio/internal/capabilities/capability.go.tmpl
+++ b/internal/generators/templates/go/stdio/internal/capabilities/capability.go.tmpl
@@ -7,7 +7,7 @@ type {{.Capability.Name}}Capability struct{}
 
 // New{{.Capability.Name }}Capability creates a new {{.Capability.Name}} capability
 func New{{.Capability.Name}}Capability() *{{.Capability.Name}}Capability {
-        return &{{.Capability.Name}}Capability{}
+	return &{{.Capability.Name}}Capability{}
 }
 
 // Enable executes the capability logic

--- a/internal/generators/templates/go/stdio/internal/resources/resource.go.tmpl
+++ b/internal/generators/templates/go/stdio/internal/resources/resource.go.tmpl
@@ -7,7 +7,7 @@ type {{.Resource.Name}}Resource struct{}
 
 // New{{.Resource.Name }}Resource creates a new {{.Resource.Name}} resource
 func New{{.Resource.Name}}Resource() *{{.Resource.Name}}Resource {
-        return &{{.Resource.Name}}Resource{}
+	return &{{.Resource.Name}}Resource{}
 }
 
 // Read executes the resource logic

--- a/internal/generators/templates/go/stdio/internal/resources/resource.go.tmpl
+++ b/internal/generators/templates/go/stdio/internal/resources/resource.go.tmpl
@@ -3,15 +3,15 @@ package resources
 import "{{.ModuleName}}/pkg/mcp"
 
 // {{.Resource.Name}} resource
-type {{.Resource.Name }}Resource struct{}
+type {{.Resource.Name}}Resource struct{}
 
 // New{{.Resource.Name }}Resource creates a new {{.Resource.Name}} resource
-func New{{.Resource.Name }}Resource() *{{.Resource.Name }}Resource {
-	return &{{.Resource.Name }}Resource{}
+func New{{.Resource.Name}}Resource() *{{.Resource.Name}}Resource {
+        return &{{.Resource.Name}}Resource{}
 }
 
 // Read executes the resource logic
-func (r *{{.Resource.Name }}Resource) Read(req mcp.Request) mcp.Response {
+func (r *{{.Resource.Name}}Resource) Read(req mcp.Request) mcp.Response {
 	// TODO: Implement resource logic for {{.Resource.Name}}
 	return mcp.Response{
 		Result: map[string]interface{}{


### PR DESCRIPTION
## Summary
- remove trailing spaces in resource and capability templates

These spaces caused the scaffolded Go server to fail to build because generated type names contained spaces.

## Testing
- `go test ./...` *(fails: Forbidden to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_6882e08d1250832faabd2d3baf50a6b3