### PR TITLE
Fix unused import in filesystem template

### DIFF
--- a/internal/generators/templates/go/stdio/internal/resources/filesystem.go.tmpl
+++ b/internal/generators/templates/go/stdio/internal/resources/filesystem.go.tmpl
@@ -3,7 +3,6 @@ package resources
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"{{.ModuleName}}/pkg/mcp"
 )
 
@@ -109,12 +108,12 @@ func (fs *FileSystemResource) ReadFile(req mcp.Request) mcp.Response {
 
 	return mcp.Response{
 		Result: map[string]interface{}{
-			"path":     path,
-			"content":  string(content),
-			"size":     info.Size(),
-			"modTime":  info.ModTime(),
-			"isDir":    info.IsDir(),
+			"path":    path,
+			"content": string(content),
+			"size":    info.Size(),
+			"modTime": info.ModTime(),
+			"isDir":   info.IsDir(),
 		},
 		ID: req.ID,
 	}
-} 
+}


### PR DESCRIPTION
## Summary
- remove the unused `path/filepath` import from `filesystem.go.tmpl`

The Go generator produced code that failed to build due to an unused import in the generated FileSystemResource.

## Testing
- `go test ./...` *(fails: missing dependencies due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6882e76d7cac832fa00abca7d7885c61