### PR TITLE
Fix force flag in docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -32,7 +32,7 @@ go build -o mcpcli ./cmd/mcpcli
                     <li><code>--docker, -d</code> Include Docker support</li>
                     <li><code>--examples, -e</code> Include example resources and tools</li>
                     <li><code>--output, -o</code> Output directory (default: project name)</li>
-                    <li><code>--foorce, -f</code> Overwrite existing directory <span style="color:#e53e3e">(note: flag is currently <code>--foorce</code> due to a typo)</span></li>
+                    <li><code>--force, -f</code> Overwrite existing directory</li>
                 </ul>
             </div>
             <div class="step">


### PR DESCRIPTION
## Summary
- correct the force flag typo in docs

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688420a2f924832f98a4dc1e297d4cab