### PR TITLE
Add command flag tests

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,24 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test ./...

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateCmd_FlagParsingAndExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "out")
+
+	cmd := NewGenerateCmd()
+	cmd.SetArgs([]string{
+		"--name", "myproj",
+		"--language", "golang",
+		"--transport", "stdio",
+		"--output", output,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	if name != "myproj" {
+		t.Errorf("expected name 'myproj', got %s", name)
+	}
+	lang, _ := cmd.Flags().GetString("language")
+	if lang != "golang" {
+		t.Errorf("expected language 'golang', got %s", lang)
+	}
+
+	if stat, err := os.Stat(output); err != nil || !stat.IsDir() {
+		t.Errorf("expected output directory to be created: %v", err)
+	}
+}

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aawadall/mcpcli/internal/core"
+)
+
+func writeTempConfig(t *testing.T, dir string) string {
+	cfg := &core.MCPConfig{
+		Name:      "test",
+		Version:   "0.1.0",
+		Transport: core.Transport{Type: "stdio"},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTestCmd_FlagParsingAndExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := writeTempConfig(t, tmpDir)
+	script := filepath.Join(tmpDir, "script.txt")
+
+	cmd := NewTestCmd()
+	cmd.SetArgs([]string{"--config", cfg, "--script", script})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	confVal, _ := cmd.Flags().GetString("config")
+	if confVal != cfg {
+		t.Errorf("expected config %s, got %s", cfg, confVal)
+	}
+	scriptVal, _ := cmd.Flags().GetString("script")
+	if scriptVal != script {
+		t.Errorf("expected script %s, got %s", script, scriptVal)
+	}
+}


### PR DESCRIPTION
## Summary
- add basic tests for `generate` command flag parsing and execution
- add basic tests for `test` command flag parsing and script handling

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_688420a54dd8832f89d10a692043c8e9