### PR TITLE
Add JavaScript next steps to generator

### DIFF
--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -377,6 +377,9 @@ func generateProject(opts *GenerateOptions) error {
 	if opts.Language == "go" || opts.Language == "golang" {
 		fmt.Printf("   go mod tidy\n")
 		fmt.Printf("   go run cmd/%s/main.go\n", opts.Transport)
+	} else if opts.Language == "javascript" {
+		fmt.Printf("   npm install\n")
+		fmt.Printf("   node src/index.js\n")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- print follow-up steps for JavaScript projects in the `generate` command

## Testing
- `go test ./internal/...` *(fails: `Forbidden` while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68842437fd20832fa73dcb4ae26fbed2