### PR TITLE
Add Python generator for mcpcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and ot
 
 ## Features
 - Generate new MCP server projects with a single command
-- Supports multiple languages (Go, Node.js, Java); Python support planned
+- Supports multiple languages (Go, Node.js, Java, Python)
 - Choose transport method (stdio, rest, websocket)
 - Optional Docker support
 - Example resources and tools included

--- a/docs/features.html
+++ b/docs/features.html
@@ -13,10 +13,10 @@
                 <span class="badge-implemented">Go</span>
                 <span class="badge-implemented">Node.js</span>
                 <span class="badge-implemented">Java</span>
-                <span class="badge-planned">Python (planned)</span>
+                <span class="badge-implemented">Python</span>
                 <div class="feature-icon">🔧</div>
                 <h3>Multiple Languages</h3>
-                <p>Support for Go, Node.js, and Java <span class="badge-implemented">(available)</span>. Python <span class="badge-planned">(planned)</span>. Choose your preferred language and get started immediately.</p>
+                <p>Support for Go, Node.js, Java, and Python <span class="badge-implemented">(available)</span>. Choose your preferred language and get started immediately.</p>
             </div>
             <div class="feature-card">
                 <span class="badge-implemented">Stdio</span>

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -287,7 +287,7 @@ func validateOptions(opts *GenerateOptions) error {
 	}
 
 	// validate language
-	validLanguages := []string{"golang", "javascript", "java"}
+	validLanguages := []string{"golang", "javascript", "java", "python"}
 	if !contains(validLanguages, opts.Language) {
 		return fmt.Errorf("invalid language: %s, valid options are: %v", opts.Language, validLanguages)
 	}
@@ -358,6 +358,8 @@ func generateProject(opts *GenerateOptions) error {
 		generator = generators.NewNodeGenerator()
 	case "java":
 		generator = generators.NewJavaGenerator()
+	case "python":
+		generator = generators.NewPythonGenerator()
 	default:
 		return fmt.Errorf("language %s is not supported yet", opts.Language)
 	}
@@ -385,6 +387,8 @@ func generateProject(opts *GenerateOptions) error {
 	} else if opts.Language == "java" {
 		fmt.Printf("   mvn package\n")
 		fmt.Printf("   java -jar target/%s-1.0.0.jar\n", opts.Name)
+	} else if opts.Language == "python" {
+		fmt.Printf("   python src/main.py\n")
 	}
 
 	return nil

--- a/internal/generators/python.go
+++ b/internal/generators/python.go
@@ -1,0 +1,122 @@
+package generators
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/aawadall/mcpcli/internal/core"
+	"github.com/fatih/color"
+)
+
+// PythonGenerator implements the Generator interface for Python projects
+type PythonGenerator struct{}
+
+func NewPythonGenerator() *PythonGenerator { return &PythonGenerator{} }
+
+func (g *PythonGenerator) GetLanguage() string { return "python" }
+
+func (g *PythonGenerator) GetSupportedTransports() []string { return []string{"stdio"} }
+
+func (g *PythonGenerator) Generate(config *core.ProjectConfig) error {
+	data := config.GetTemplateData()
+	if err := g.createDirectoryStructure(config.Output); err != nil {
+		return fmt.Errorf("failed to create directory structure: %w", err)
+	}
+	if err := g.generateFromTemplates(config.Output, data); err != nil {
+		return fmt.Errorf("failed to generate from templates: %w", err)
+	}
+	return nil
+}
+
+func (g *PythonGenerator) createDirectoryStructure(output string) error {
+	dirs := []string{
+		"src/handlers",
+		"src/resources",
+		"src/tools",
+		"src/capabilities",
+		"examples",
+		"configs",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(output, d), 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *PythonGenerator) generateFromTemplates(output string, data *core.TemplateData) error {
+	templates := map[string]string{
+		"templates/python/stdio/src/main.py.tmpl":               "src/main.py",
+		"templates/python/stdio/src/handlers/mcp.py.tmpl":       "src/handlers/mcp.py",
+		"templates/python/stdio/src/resources/registry.py.tmpl": "src/resources/registry.py",
+		"templates/python/stdio/README.md.tmpl":                 "README.md",
+		"templates/python/stdio/configs/mcp-config.json.tmpl":   "configs/mcp-config.json",
+		"templates/python/stdio/examples/example.py.tmpl":       "examples/example.py",
+	}
+	for tPath, outPath := range templates {
+		if err := g.generateTemplate(tPath, filepath.Join(output, outPath), data); err != nil {
+			return err
+		}
+	}
+	if data.Config.Docker {
+		dockerTemps := map[string]string{
+			"templates/python/stdio/Dockerfile.tmpl":   "Dockerfile",
+			"templates/python/stdio/dockerignore.tmpl": ".dockerignore",
+		}
+		for tPath, outPath := range dockerTemps {
+			if err := g.generateTemplate(tPath, filepath.Join(output, outPath), data); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, tool := range data.Config.Tools {
+		td := struct{ Tool core.Tool }{Tool: tool}
+		file := filepath.Join(output, "src/tools", tool.Name+".py")
+		if err := g.generateTemplate("templates/python/stdio/src/tools/tool.py.tmpl", file, td); err != nil {
+			return err
+		}
+	}
+
+	for _, res := range data.Config.Resources {
+		rd := struct{ Resource core.Resource }{Resource: res}
+		file := filepath.Join(output, "src/resources", res.Name+".py")
+		if err := g.generateTemplate("templates/python/stdio/src/resources/resource.py.tmpl", file, rd); err != nil {
+			return err
+		}
+	}
+
+	for _, cap := range data.Config.Capabilities {
+		cd := struct{ Capability core.Capability }{Capability: cap}
+		file := filepath.Join(output, "src/capabilities", cap.Name+".py")
+		if err := g.generateTemplate("templates/python/stdio/src/capabilities/capability.py.tmpl", file, cd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *PythonGenerator) generateTemplate(tPath, outPath string, data interface{}) error {
+	content, err := TemplatesFS.ReadFile(tPath)
+	if err != nil {
+		return fmt.Errorf("failed to read template %s: %w", tPath, err)
+	}
+	tmpl, err := template.New(filepath.Base(tPath)).Parse(string(content))
+	if err != nil {
+		return fmt.Errorf("failed to parse template %s: %w", tPath, err)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", outPath, err)
+	}
+	defer f.Close()
+	if err := tmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("failed to execute template %s: %w", tPath, err)
+	}
+	color.Green("✅ Created file: %s", outPath)
+	return nil
+}

--- a/internal/generators/python_test.go
+++ b/internal/generators/python_test.go
@@ -1,0 +1,57 @@
+package generators
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aawadall/mcpcli/internal/core"
+)
+
+func TestPythonGenerator_GetLanguage(t *testing.T) {
+	g := NewPythonGenerator()
+	if g.GetLanguage() != "python" {
+		t.Errorf("expected language 'python', got '%s'", g.GetLanguage())
+	}
+}
+
+func TestPythonGenerator_GetSupportedTransports(t *testing.T) {
+	g := NewPythonGenerator()
+	tr := g.GetSupportedTransports()
+	if len(tr) == 0 {
+		t.Error("expected at least one supported transport")
+	}
+	if tr[0] != "stdio" {
+		t.Errorf("expected transport 'stdio', got '%s'", tr[0])
+	}
+}
+
+func TestPythonGenerator_GenerateBasic(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &core.ProjectConfig{
+		Name:      "testpython",
+		Language:  "python",
+		Transport: "stdio",
+		Output:    tmpDir,
+	}
+
+	g := NewPythonGenerator()
+	if err := g.Generate(cfg); err != nil {
+		t.Fatalf("unexpected error generating project: %v", err)
+	}
+
+	expected := []string{
+		filepath.Join(tmpDir, "src", "main.py"),
+	}
+
+	for _, f := range expected {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Errorf("expected file %s to exist, but got error: %v", f, err)
+			continue
+		}
+		if info.IsDir() {
+			t.Errorf("expected file %s to be a file, but it is a directory", f)
+		}
+	}
+}

--- a/internal/generators/templates/python/stdio/Dockerfile.tmpl
+++ b/internal/generators/templates/python/stdio/Dockerfile.tmpl
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+CMD ["python","src/main.py"]

--- a/internal/generators/templates/python/stdio/README.md.tmpl
+++ b/internal/generators/templates/python/stdio/README.md.tmpl
@@ -1,0 +1,10 @@
+# {{.Config.Name}} MCP Server (Python)
+
+This is a Model Context Protocol (MCP) server implemented in Python.
+
+## Getting Started
+
+```bash
+cd {{.Config.Output}}
+python src/main.py
+```

--- a/internal/generators/templates/python/stdio/configs/mcp-config.json.tmpl
+++ b/internal/generators/templates/python/stdio/configs/mcp-config.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "name": "{{ .Config.Name }}",
+  "language": "{{ .Config.Language }}",
+  "transport": {
+    "type": "{{ .Config.Transport }}",
+    "options": { "command": "python src/main.py" }
+  },
+  "docker": {{ .Config.Docker }},
+  "examples": {{ .Config.Examples }}
+}

--- a/internal/generators/templates/python/stdio/dockerignore.tmpl
+++ b/internal/generators/templates/python/stdio/dockerignore.tmpl
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/internal/generators/templates/python/stdio/examples/example.py.tmpl
+++ b/internal/generators/templates/python/stdio/examples/example.py.tmpl
@@ -1,0 +1,5 @@
+from handlers.mcp import handle_request
+
+print('Example: list resources')
+res = handle_request({'method': 'resources/list', 'id': 1})
+print(res)

--- a/internal/generators/templates/python/stdio/src/capabilities/capability.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/capabilities/capability.py.tmpl
@@ -1,0 +1,6 @@
+def {{.Capability.Name}}(req):
+    # TODO: implement capability logic for {{.Capability.Name}}
+    return {
+        'result': {'message': f'Capability {{.Capability.Name}} enabled'},
+        'id': req.get('id')
+    }

--- a/internal/generators/templates/python/stdio/src/handlers/mcp.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/handlers/mcp.py.tmpl
@@ -1,0 +1,42 @@
+from resources.registry import registered_resources
+
+
+def handle_request(req):
+    method = req.get('method')
+    if method == 'resources/list':
+        return handle_list_resources(req)
+    elif method == 'resources/read':
+        return handle_read_resource(req)
+    elif method == 'tools/list':
+        return handle_list_tools(req)
+    elif method == 'tools/call':
+        return handle_call_tool(req)
+    else:
+        return {'error': {'code': -32601, 'message': f'Method not found: {method}'}, 'id': req.get('id')}
+
+
+def handle_list_resources(req):
+    return {'result': {'resources': registered_resources}, 'id': req.get('id')}
+
+
+def handle_read_resource(req):
+    uri = req.get('params', {}).get('uri')
+    if not uri:
+        return {'error': {'code': -32602, 'message': 'Invalid params: uri is required'}, 'id': req.get('id')}
+    # TODO: Implement reading the resource
+    return {'error': {'code': -32601, 'message': 'Read resource functionality not implemented'}, 'id': req.get('id')}
+
+
+def handle_list_tools(req):
+    return {'result': {'tools': []}, 'id': req.get('id')}
+
+
+def handle_call_tool(req):
+    tool_name = req.get('params', {}).get('toolName')
+    args = req.get('params', {}).get('arguments')
+    if not tool_name or not isinstance(tool_name, str):
+        return {'error': {'code': -32602, 'message': 'Invalid params: toolName is required and must be a string'}, 'id': req.get('id')}
+    if args is None or not isinstance(args, (dict, list)):
+        return {'error': {'code': -32602, 'message': 'Invalid params: arguments must be an object or an array'}, 'id': req.get('id')}
+    # TODO: Implement calling tools
+    return {'error': {'code': -32601, 'message': 'No tools defined'}, 'id': req.get('id')}

--- a/internal/generators/templates/python/stdio/src/main.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/main.py.tmpl
@@ -1,0 +1,16 @@
+import sys
+import json
+from handlers.mcp import handle_request
+
+print(f"Starting {{ .Config.Name }} MCP Server (stdio mode)...", file=sys.stderr)
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        req = json.loads(line)
+        res = handle_request(req)
+        print(json.dumps(res))
+    except Exception as e:
+        print(f"Error processing request: {e}", file=sys.stderr)

--- a/internal/generators/templates/python/stdio/src/resources/registry.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/resources/registry.py.tmpl
@@ -1,0 +1,5 @@
+registered_resources = [
+{{- range $i, $res := .Config.Resources }}
+    {"uri": "{{ $res.Name }}", "name": "{{ $res.Name }}", "type": "{{ $res.Type }}"},
+{{- end }}
+]

--- a/internal/generators/templates/python/stdio/src/resources/resource.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/resources/resource.py.tmpl
@@ -1,0 +1,6 @@
+def {{.Resource.Name}}(req):
+    # TODO: implement resource logic for {{.Resource.Name}}
+    return {
+        'result': {'message': f'Resource {{.Resource.Name}} read'},
+        'id': req.get('id')
+    }

--- a/internal/generators/templates/python/stdio/src/tools/tool.py.tmpl
+++ b/internal/generators/templates/python/stdio/src/tools/tool.py.tmpl
@@ -1,0 +1,6 @@
+def {{.Tool.Name}}(req):
+    # TODO: implement tool logic for {{.Tool.Name}}
+    return {
+        'result': {'message': f'Tool {{.Tool.Name}} executed'},
+        'id': req.get('id')
+    }


### PR DESCRIPTION
## Summary
- support Python when generating MCP server projects
- document Python support in CLI documentation and feature page
- include new Python templates for stdio projects
- add tests for Python generator

## Testing
- `go test ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6884eace9220832f8bc4d11d42a996c6