### PR TITLE
Release v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and other languages. It generates ready-to-use MCP server templates with support for multiple transports, Docker, and example resources/tools.
 
+**Current Version:** v0.4.0
+
 > Learn more about the Model Context Protocol at the [official introduction page](https://modelcontextprotocol.io/introduction).
 
 ## Features

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "0.4.0"
 
 func main() {
 	rootCmd := &cobra.Command{

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -2,6 +2,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
+        <p><strong>Version:</strong> v0.4.0</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -12,7 +12,7 @@ import (
 func writeTempConfig(t *testing.T, dir string) string {
 	cfg := &core.MCPConfig{
 		Name:      "test",
-		Version:   "0.1.0",
+		Version:   "0.4.0",
 		Transport: core.Transport{Type: "stdio"},
 	}
 	data, err := json.Marshal(cfg)

--- a/internal/core/projectconfig.go
+++ b/internal/core/projectconfig.go
@@ -22,7 +22,7 @@ type ProjectConfig struct {
 // NewProjectConfig creates a new project configuration with defaults
 func NewProjectConfig() *ProjectConfig {
 	return &ProjectConfig{
-		Version:   "0.1.0",
+		Version:   "0.4.0",
 		CreatedAt: time.Now(),
 	}
 }


### PR DESCRIPTION
## Summary
- bump application version to v0.4.0
- mention the current version in README and docs

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed8c2864832fb44996472de17140