### PR TITLE
Fix import in Java template

### DIFF
--- a/internal/generators/templates/java/stdio/src/main/java/Main.java.tmpl
+++ b/internal/generators/templates/java/stdio/src/main/java/Main.java.tmpl
@@ -2,7 +2,7 @@ package {{.PackageName}};
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import handlers.MCPHandler;
+import {{.PackageName}}.handlers.MCPHandler;
 import org.json.JSONObject;
 
 public class Main {


### PR DESCRIPTION
## Summary
- fix incorrect `handlers` import in Java template

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68856798bc94832fa200f15575295035