### PR TITLE
Improve JSON parsing error details

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -92,7 +92,7 @@ func loadMCPConfig(configPath string) (*core.MCPConfig, error) {
 	// If that fails, try to load as MCPConfig directly
 	var config core.MCPConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+		return nil, core.FormatJSONError(data, err, "failed to parse config file")
 	}
 
 	return &config, nil

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aawadall/mcpcli/internal/core"
@@ -45,5 +46,19 @@ func TestTestCmd_FlagParsingAndExecution(t *testing.T) {
 	scriptVal, _ := cmd.Flags().GetString("script")
 	if scriptVal != script {
 		t.Errorf("expected script %s, got %s", script, scriptVal)
+	}
+}
+
+func TestLoadMCPConfig_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	bad := filepath.Join(tmpDir, "bad.json")
+	os.WriteFile(bad, []byte("{invalid}"), 0644)
+
+	_, err := loadMCPConfig(bad)
+	if err == nil {
+		t.Fatal("expected error for invalid json")
+	}
+	if !strings.Contains(err.Error(), "line") || !strings.Contains(err.Error(), "column") {
+		t.Errorf("expected line and column info in error, got %v", err)
 	}
 }

--- a/internal/core/jsonutil.go
+++ b/internal/core/jsonutil.go
@@ -7,9 +7,9 @@ import (
 )
 
 // lineAndColumn calculates 1-based line and column numbers from a byte offset.
-func lineAndColumn(data []byte, offset int64) (line, column int) {
+func lineAndColumn(data []byte, offset int64) (line, column int, err error) {
 	if offset < 0 {
-		return 0, 0
+		return 0, 0, fmt.Errorf("invalid offset: %d", offset)
 	}
 	line = 1
 	column = 1

--- a/internal/core/jsonutil.go
+++ b/internal/core/jsonutil.go
@@ -24,7 +24,7 @@ func lineAndColumn(data []byte, offset int64) (line, column int) {
 	return
 }
 
-// formatJSONError adds line and column information to json errors when possible.
+// FormatJSONError adds line and column information to JSON errors when possible.
 func FormatJSONError(data []byte, err error, context string) error {
 	var syntaxErr *json.SyntaxError
 	var typeErr *json.UnmarshalTypeError

--- a/internal/core/jsonutil.go
+++ b/internal/core/jsonutil.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// lineAndColumn calculates 1-based line and column numbers from a byte offset.
+func lineAndColumn(data []byte, offset int64) (line, column int) {
+	if offset < 0 {
+		return 0, 0
+	}
+	line = 1
+	column = 1
+	for i := int64(0); i < int64(len(data)) && i < offset; i++ {
+		if data[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return
+}
+
+// formatJSONError adds line and column information to json errors when possible.
+func FormatJSONError(data []byte, err error, context string) error {
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	switch {
+	case errors.As(err, &syntaxErr):
+		l, c := lineAndColumn(data, syntaxErr.Offset)
+		return fmt.Errorf("%s at line %d, column %d: %w", context, l, c, err)
+	case errors.As(err, &typeErr):
+		l, c := lineAndColumn(data, typeErr.Offset)
+		return fmt.Errorf("%s at line %d, column %d: %w", context, l, c, err)
+	default:
+		return fmt.Errorf("%s: %w", context, err)
+	}
+}

--- a/internal/core/jsonutil.go
+++ b/internal/core/jsonutil.go
@@ -13,7 +13,8 @@ func lineAndColumn(data []byte, offset int64) (line, column int, err error) {
 	}
 	line = 1
 	column = 1
-	for i := int64(0); i < int64(len(data)) && i < offset; i++ {
+	dataLen := int64(len(data))
+	for i := int64(0); i < dataLen && i < offset; i++ {
 		if data[i] == '\n' {
 			line++
 			column = 1

--- a/internal/core/jsonutil.go
+++ b/internal/core/jsonutil.go
@@ -31,10 +31,16 @@ func FormatJSONError(data []byte, err error, context string) error {
 	var typeErr *json.UnmarshalTypeError
 	switch {
 	case errors.As(err, &syntaxErr):
-		l, c := lineAndColumn(data, syntaxErr.Offset)
+		l, c, lcErr := lineAndColumn(data, syntaxErr.Offset)
+		if lcErr != nil {
+			return fmt.Errorf("%s: could not determine line and column: %w", context, err)
+		}
 		return fmt.Errorf("%s at line %d, column %d: %w", context, l, c, err)
 	case errors.As(err, &typeErr):
-		l, c := lineAndColumn(data, typeErr.Offset)
+		l, c, lcErr := lineAndColumn(data, typeErr.Offset)
+		if lcErr != nil {
+			return fmt.Errorf("%s: could not determine line and column: %w", context, err)
+		}
 		return fmt.Errorf("%s at line %d, column %d: %w", context, l, c, err)
 	default:
 		return fmt.Errorf("%s: %w", context, err)

--- a/internal/core/jsonutil_test.go
+++ b/internal/core/jsonutil_test.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatJSONError_Syntax(t *testing.T) {
+	data := []byte("{\n\"key\": \"value\",,\n}")
+	var v interface{}
+	err := json.Unmarshal(data, &v)
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+	ferr := FormatJSONError(data, err, "parse failed")
+	if ferr == nil {
+		t.Fatal("expected formatted error")
+	}
+	if !strings.Contains(ferr.Error(), "line") || !strings.Contains(ferr.Error(), "column") {
+		t.Errorf("expected line and column info, got %v", ferr)
+	}
+}

--- a/internal/core/mcpclient.go
+++ b/internal/core/mcpclient.go
@@ -53,8 +53,9 @@ func (c *MCPClient) ReadResponse() (*Response, error) {
 		return nil, fmt.Errorf("no response received")
 	}
 	var response Response
-	if err := json.Unmarshal([]byte(scanner.Text()), &response); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	text := scanner.Text()
+	if err := json.Unmarshal([]byte(text), &response); err != nil {
+		return nil, FormatJSONError([]byte(text), err, "failed to unmarshal response")
 	}
 	return &response, nil
 }


### PR DESCRIPTION
## Summary
- add `FormatJSONError` helper to report line and column information on JSON errors
- use the new helper in config loading and MCP client
- test JSON error formatting and invalid config loading

Fixing issue #20 
## Testing
- `go test ./... -coverprofile=coverage.out` *(fails: unable to fetch Go modules)*
