### PR TITLE
Fix docs format and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and other languages. It generates ready-to-use MCP server templates with support for multiple transports, Docker, and example resources/tools.
 
-**Current Version:** v0.4.0
+**Current Version:** v0.4.1
 
 > Learn more about the Model Context Protocol at the [official introduction page](https://modelcontextprotocol.io/introduction).
 
@@ -118,4 +118,4 @@ MIT License
 ---
 
 ## Further Reading
-- [Model Context Protocol Introduction](https://modelcontextprotocol.io/introduction) 
+- [Model Context Protocol Introduction](https://modelcontextprotocol.io/introduction)

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.4.0"
+var version = "0.4.1"
 
 func main() {
 	rootCmd := &cobra.Command{

--- a/doc/patterns.md
+++ b/doc/patterns.md
@@ -27,4 +27,4 @@
 
 ## 6. Separation of Concerns
 - CLI logic, code generation, and template data are separated into different packages
-- Templates are kept language- and transport-specific for clarity 
+- Templates are kept language- and transport-specific for clarity

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -2,7 +2,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.0</p>
+        <p><strong>Version:</strong> v0.4.1</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -13,7 +13,7 @@ import (
 func writeTempConfig(t *testing.T, dir string) string {
 	cfg := &core.MCPConfig{
 		Name:      "test",
-		Version:   "0.4.0",
+		Version:   "0.4.1",
 		Transport: core.Transport{Type: "stdio"},
 	}
 	data, err := json.Marshal(cfg)

--- a/internal/core/projectconfig.go
+++ b/internal/core/projectconfig.go
@@ -22,7 +22,7 @@ type ProjectConfig struct {
 // NewProjectConfig creates a new project configuration with defaults
 func NewProjectConfig() *ProjectConfig {
 	return &ProjectConfig{
-		Version:   "0.4.0",
+		Version:   "0.4.1",
 		CreatedAt: time.Now(),
 	}
 }


### PR DESCRIPTION
## Summary
- fix markdown formatting in README and patterns doc
- bump CLI version to v0.4.1
- update generated project defaults and tests
- update documentation site with new version

## Testing
- `go test ./... -coverprofile=coverage.out` *(fails: `proxy.golang.org` blocked)*
- `go vet ./...` *(fails: `proxy.golang.org` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688572914b64832fba095a1eeb5915a1