### PR TITLE
Refactor Python generator and enforce coverage

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -20,5 +20,12 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests with coverage
+        run: |
+          go test ./... -coverprofile=coverage.out -covermode=atomic
+          go tool cover -func=coverage.out
+      - name: Ensure coverage
+        run: |
+          pct=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          echo "total coverage: $pct%"
+          if (( $(echo "$pct < 85" | bc -l) )); then exit 1; fi

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           pct=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
           echo "total coverage: $pct%"
-          if (( $(echo "$pct < 85" | bc -l) )); then exit 1; fi
+          if [ $(echo "$pct 85" | awk '{print ($1 < $2)}') -eq 1 ]; then exit 1; fi

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ A generated Node.js MCP server project includes:
 - `configs/mcp-config.json` - Server configuration
 - `Dockerfile` - Docker support (optional)
 
+## Testing
+
+Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
+
 ## Contributing
 
 Contributions are welcome! Please open issues or pull requests.

--- a/internal/generators/python_test.go
+++ b/internal/generators/python_test.go
@@ -55,3 +55,33 @@ func TestPythonGenerator_GenerateBasic(t *testing.T) {
 		}
 	}
 }
+
+func TestPythonGenerator_GenerateWithExtras(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &core.ProjectConfig{
+		Name:         "extras",
+		Language:     "python",
+		Transport:    "stdio",
+		Output:       tmpDir,
+		Tools:        []core.Tool{{Name: "tool"}},
+		Resources:    []core.Resource{{Name: "res"}},
+		Capabilities: []core.Capability{{Name: "cap"}},
+	}
+
+	g := NewPythonGenerator()
+	if err := g.Generate(cfg); err != nil {
+		t.Fatalf("unexpected error generating project: %v", err)
+	}
+
+	expected := []string{
+		filepath.Join(tmpDir, "src", "tools", "tool.py"),
+		filepath.Join(tmpDir, "src", "resources", "res.py"),
+		filepath.Join(tmpDir, "src", "capabilities", "cap.py"),
+	}
+
+	for _, f := range expected {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %s to exist, got %v", f, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- refactor `python.go` to share template generation logic
- add additional tests for Python generator
- update workflow to check code coverage and ensure 85% minimum
- document testing instructions in README

## Testing
- [x] unit testing
