### PR TITLE
Add core tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A generated Node.js MCP server project includes:
 ## Testing
 
 Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
-See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.1**.
+See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli {{VERSION}}**.
 All contributions must maintain this minimum coverage level.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A generated Node.js MCP server project includes:
 ## Testing
 
 Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
+See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.1**.
 All contributions must maintain this minimum coverage level.
 
 ## Contributing

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -14,4 +14,4 @@ To check code coverage, run:
 go test ./internal/core -cover
 ```
 
-The test suite currently targets **mcpcli {{VERSION}}** and achieves over 85% coverage for the core package.
+The test suite currently targets **mcpcli 1.0.0** and achieves over 85% coverage for the core package.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,17 @@
+# Running Tests
+
+This guide describes how to run the unit tests for `mcpcli`.
+
+The project targets Go `1.22` and requires no external services. Run all tests with:
+
+```bash
+go test ./...
+```
+
+To check code coverage, run:
+
+```bash
+go test ./internal/core -cover
+```
+
+The test suite currently targets **mcpcli v0.4.1** and achieves over 85% coverage for the core package.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -14,4 +14,4 @@ To check code coverage, run:
 go test ./internal/core -cover
 ```
 
-The test suite currently targets **mcpcli v0.4.1** and achieves over 85% coverage for the core package.
+The test suite currently targets **mcpcli {{VERSION}}** and achieves over 85% coverage for the core package.

--- a/internal/core/jsonutil_test.go
+++ b/internal/core/jsonutil_test.go
@@ -21,3 +21,24 @@ func TestFormatJSONError_Syntax(t *testing.T) {
 		t.Errorf("expected line and column info, got %v", ferr)
 	}
 }
+
+func TestFormatJSONError_Type(t *testing.T) {
+	data := []byte("{\"num\":\"bad\"}")
+	var v struct {
+		Num int `json:"num"`
+	}
+	err := json.Unmarshal(data, &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	ferr := FormatJSONError(data, err, "failed")
+	if ferr == nil || !strings.Contains(ferr.Error(), "line") {
+		t.Errorf("expected line/column info, got %v", ferr)
+	}
+}
+
+func TestLineAndColumnInvalidOffset(t *testing.T) {
+	if _, _, err := lineAndColumn([]byte("abc"), -1); err == nil {
+		t.Error("expected error for negative offset")
+	}
+}

--- a/internal/core/mcpclient_test.go
+++ b/internal/core/mcpclient_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestSanitizeURI(t *testing.T) {
+	uri, err := sanitizeURI(" http://example.com ")
+	if err != nil || uri != "http://example.com" {
+		t.Fatalf("unexpected sanitize result %s %v", uri, err)
+	}
+	if _, err := sanitizeURI("::bad::"); err == nil {
+		t.Error("expected error for bad uri")
+	}
+}
+
+func TestMCPClientSendAndRead(t *testing.T) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	c := NewMCPClientWithIO(in, out, io.Discard)
+	req := &Request{Method: "ping"}
+	if err := c.SendRequest(req); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Error("expected output to be written")
+	}
+	respJSON := `{"result":"pong"}`
+	in.WriteString(respJSON + "\n")
+	resp, err := c.ReadResponse()
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if resp.Result != "pong" {
+		t.Errorf("unexpected result %v", resp.Result)
+	}
+}
+
+func TestMCPClientCallHelpers(t *testing.T) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	c := NewMCPClientWithIO(in, out, errBuf)
+
+	in.WriteString(`{"result":"ok"}` + "\n")
+	resp, err := c.Call("test/method", nil, 1)
+	if err != nil {
+		t.Fatalf("call failed: %v", err)
+	}
+	if resp.Result != "ok" {
+		t.Errorf("unexpected result %v", resp.Result)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("test/method")) {
+		t.Errorf("request not sent correctly: %s", out.String())
+	}
+
+	out.Reset()
+	in.Reset()
+	in.WriteString(`{"result":null}` + "\n")
+	if _, err := c.ListResources(2); err != nil {
+		t.Fatalf("list resources failed: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("resources/list")) {
+		t.Errorf("list resources wrong request: %s", out.String())
+	}
+
+	out.Reset()
+	in.Reset()
+	in.WriteString(`{"result":null}` + "\n")
+	if _, err := c.ListTools(3); err != nil {
+		t.Fatalf("list tools failed: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("tools/list")) {
+		t.Errorf("list tools wrong request: %s", out.String())
+	}
+
+	out.Reset()
+	in.Reset()
+	in.WriteString(`{"result":null}` + "\n")
+	if _, err := c.ReadResource("http://x", 4); err != nil {
+		t.Fatalf("read resource failed: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("resources/read")) {
+		t.Errorf("read resource wrong request: %s", out.String())
+	}
+
+	out.Reset()
+	in.Reset()
+	in.WriteString(`{"result":null}` + "\n")
+	if _, err := c.CallTool("tool", nil, 5); err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("tools/call")) {
+		t.Errorf("call tool wrong request: %s", out.String())
+	}
+
+	c.PrintError("err %d", 1)
+	c.PrintInfo("info %d", 2)
+	if !bytes.Contains(errBuf.Bytes(), []byte("err 1")) || !bytes.Contains(errBuf.Bytes(), []byte("info 2")) {
+		t.Errorf("stderr not written correctly: %s", errBuf.String())
+	}
+}

--- a/internal/core/projectconfig_test.go
+++ b/internal/core/projectconfig_test.go
@@ -1,0 +1,50 @@
+package core
+
+import "testing"
+
+func TestSanitizePackageName(t *testing.T) {
+	cases := map[string]string{
+		"my-project": "my_project",
+		"1bad-name":  "pkgbad_name",
+		"HelloWorld": "HelloWorld",
+	}
+	for input, expected := range cases {
+		if out := sanitizePackageName(input); out != expected {
+			t.Errorf("%s => %s, want %s", input, out, expected)
+		}
+	}
+}
+
+func TestGetTransportOptions(t *testing.T) {
+	rest := getTransportOptions("rest")
+	if rest["port"] != 8080 || rest["host"] != "localhost" {
+		t.Errorf("unexpected rest options: %v", rest)
+	}
+	ws := getTransportOptions("websocket")
+	if ws["port"] != 8081 || ws["path"] != "/ws" {
+		t.Errorf("unexpected websocket options: %v", ws)
+	}
+	if getTransportOptions("stdio") != nil {
+		t.Error("expected nil for stdio transport")
+	}
+}
+
+func TestNewProjectConfig_GetTemplateData(t *testing.T) {
+	pc := NewProjectConfig()
+	pc.Name = "example"
+	pc.Transport = "rest"
+	data := pc.GetTemplateData()
+	if data.Config != pc {
+		t.Error("template data should reference original config")
+	}
+	if data.PackageName != "example" {
+		t.Errorf("expected package name 'example', got %s", data.PackageName)
+	}
+	if data.MCPConfig.Transport.Type != "rest" {
+		t.Errorf("expected transport 'rest', got %s", data.MCPConfig.Transport.Type)
+	}
+	opts := data.MCPConfig.Transport.Options
+	if opts["port"] != 8080 {
+		t.Errorf("unexpected port %v", opts["port"])
+	}
+}

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -1,0 +1,15 @@
+package core
+
+import "testing"
+
+func TestIsValidResourceType(t *testing.T) {
+	valid := []string{"database", "filesystem", "time"}
+	for _, v := range valid {
+		if !IsValidResourceType(v) {
+			t.Errorf("expected %s to be valid", v)
+		}
+	}
+	if IsValidResourceType("invalid") {
+		t.Error("unexpected valid result for invalid type")
+	}
+}


### PR DESCRIPTION
## Summary
- add documentation about running tests
- link to the new testing guide in README
- expand core package test coverage

## Testing
- `go test ./internal/core -coverprofile=coverage_core.out`
- `go test ./... -coverprofile=coverage.out` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68863fb33b64832f8b99874300cdcfd5