### PR TITLE
Add release badge and fix version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/7b1f68b2c73c49e19e13a7e25f9de2f8)](https://app.codacy.com/gh/aawadall/mcpcli/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/7b1f68b2c73c49e19e13a7e25f9de2f8)](https://app.codacy.com/gh/aawadall/mcpcli/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+[![Release](https://img.shields.io/github/v/release/aawadall/mcpcli?label=release)](https://github.com/aawadall/mcpcli/releases)
 
 # mcpcli
 
 A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and other languages. It generates ready-to-use MCP server templates with support for multiple transports, Docker, and example resources/tools.
 
-**Current Version:** v0.4.2
+**Current Version:** v0.4.1
 
 > Learn more about the Model Context Protocol at the [official introduction page](https://modelcontextprotocol.io/introduction).
 
@@ -112,7 +113,7 @@ A generated Node.js MCP server project includes:
 ## Testing
 
 Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
-See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli {{VERSION}}**.
+See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.1**.
 All contributions must maintain this minimum coverage level.
 
 ## Contributing

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is the current release tag for the CLI.
 var version = "0.4.1"
 
 func main() {

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -14,4 +14,4 @@ To check code coverage, run:
 go test ./internal/core -cover
 ```
 
-The test suite currently targets **mcpcli 1.0.0** and achieves over 85% coverage for the core package.
+The test suite currently targets **mcpcli v0.4.1** and achieves over 85% coverage for the core package.


### PR DESCRIPTION
## Summary
- add badge linking to GitHub releases in README
- update docs to show latest version v0.4.1
- document CLI version in code

## Testing
- `go test ./... -cover` *(fails: download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886438e87c4832f914be152c9587709