### PR TITLE
refactor template strings into shared utils

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -2,7 +2,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.2</p>
+        <p><strong>Version:</strong> v0.4.1</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/internal/generators/golang.go
+++ b/internal/generators/golang.go
@@ -70,39 +70,14 @@ func (g *GoGenerator) createDirectoryStructure(output string) error {
 // generateFromTemplates generates all files using the template system
 func (g *GoGenerator) generateFromTemplates(output string, data *core.TemplateData) error {
 	// Define template files and their output paths
-	templates := map[string]string{
-		"templates/go/stdio/go.mod.tmpl":                           "go.mod",
-		"templates/go/stdio/cmd/server/main.go.tmpl":               "cmd/server/main.go",
-		"templates/go/stdio/internal/handlers/mcp.go.tmpl":         "internal/handlers/mcp.go",
-		"templates/go/stdio/internal/resources/filesystem.go.tmpl": "internal/resources/filesystem.go",
-		"templates/go/stdio/internal/resources/registry.go.tmpl":   "internal/resources/registry.go",
-		"templates/go/stdio/internal/tools/calculator.go.tmpl":     "internal/tools/calculator.go",
-		"templates/go/stdio/pkg/mcp/client.go.tmpl":                "pkg/mcp/client.go",
-		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                   "pkg/mcp/mcp.go",
-
-		"templates/go/stdio/README.md.tmpl":               "README.md",
-		"templates/go/stdio/configs/mcp-config.json.tmpl": "configs/mcp-config.json",
-		"templates/go/stdio/examples/example.go.tmpl":     "examples/example.go",
+	templates, err := BaseTemplateMap(g.GetLanguage(), data)
+	if err != nil {
+		return err
 	}
 
-	// Generate each template
 	for templatePath, outputPath := range templates {
 		if err := g.generateTemplate(templatePath, filepath.Join(output, outputPath), data); err != nil {
 			return fmt.Errorf("failed to generate %s: %w", outputPath, err)
-		}
-	}
-
-	// Generate Docker files if requested
-	if data.Config.Docker {
-		dockerTemplates := map[string]string{
-			"templates/go/stdio/Dockerfile.tmpl":   "Dockerfile",
-			"templates/go/stdio/dockerignore.tmpl": ".dockerignore",
-		}
-
-		for templatePath, outputPath := range dockerTemplates {
-			if err := g.generateTemplate(templatePath, filepath.Join(output, outputPath), data); err != nil {
-				return fmt.Errorf("failed to generate %s: %w", outputPath, err)
-			}
 		}
 	}
 
@@ -116,7 +91,7 @@ func (g *GoGenerator) generateFromTemplates(output string, data *core.TemplateDa
 			Tool:       tool,
 		}
 		fileName := filepath.Join(output, "internal/tools", tool.Name+".go")
-		tmplPath := "templates/go/stdio/internal/tools/tool.go.tmpl"
+		tmplPath := ToolTemplate(g.GetLanguage())
 		if err := g.generateTemplate(tmplPath, fileName, toolData); err != nil {
 			return fmt.Errorf("failed to generate tool file for %s: %w", tool.Name, err)
 		}
@@ -132,7 +107,7 @@ func (g *GoGenerator) generateFromTemplates(output string, data *core.TemplateDa
 			Resource:   resource,
 		}
 		fileName := filepath.Join(output, "internal/resources", resource.Name+".go")
-		tmplPath := "templates/go/stdio/internal/resources/resource.go.tmpl"
+		tmplPath := ResourceTemplate(g.GetLanguage())
 		if err := g.generateTemplate(tmplPath, fileName, resourceData); err != nil {
 			return fmt.Errorf("failed to generate resource file for %s: %w", resource.Name, err)
 		}
@@ -148,7 +123,7 @@ func (g *GoGenerator) generateFromTemplates(output string, data *core.TemplateDa
 			Capability: capability,
 		}
 		fileName := filepath.Join(output, "internal/capabilities", capability.Name+".go")
-		tmplPath := "templates/go/stdio/internal/capabilities/capability.go.tmpl"
+		tmplPath := CapabilityTemplate(g.GetLanguage())
 		if err := g.generateTemplate(tmplPath, fileName, capabilityData); err != nil {
 			return fmt.Errorf("failed to generate capability file for %s: %w", capability.Name, err)
 		}

--- a/internal/generators/java.go
+++ b/internal/generators/java.go
@@ -52,29 +52,13 @@ func (g *JavaGenerator) createDirectoryStructure(output, pkg string) error {
 
 func (g *JavaGenerator) generateFromTemplates(output string, data *core.TemplateData) error {
 	pkgPath := filepath.Join(strings.Split(data.PackageName, ".")...)
-	templates := map[string]string{
-		"templates/java/stdio/pom.xml.tmpl":                                "pom.xml",
-		"templates/java/stdio/src/main/java/Main.java.tmpl":                filepath.Join("src", "main", "java", pkgPath, "Main.java"),
-		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl": filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
-		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":  filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
-		"templates/java/stdio/README.md.tmpl":                              "README.md",
-		"templates/java/stdio/configs/mcp-config.json.tmpl":                "configs/mcp-config.json",
-		"templates/java/stdio/examples/Example.java.tmpl":                  "examples/Example.java",
+	templates, err := BaseTemplateMap(g.GetLanguage(), data)
+	if err != nil {
+		return err
 	}
 	for tPath, outPath := range templates {
 		if err := g.generateTemplate(tPath, filepath.Join(output, outPath), data); err != nil {
 			return err
-		}
-	}
-	if data.Config.Docker {
-		dockerTemps := map[string]string{
-			"templates/java/stdio/Dockerfile.tmpl":   "Dockerfile",
-			"templates/java/stdio/dockerignore.tmpl": ".dockerignore",
-		}
-		for tPath, outPath := range dockerTemps {
-			if err := g.generateTemplate(tPath, filepath.Join(output, outPath), data); err != nil {
-				return err
-			}
 		}
 	}
 	for _, tool := range data.Config.Tools {
@@ -83,7 +67,7 @@ func (g *JavaGenerator) generateFromTemplates(output string, data *core.Template
 			Tool        core.Tool
 		}{PackageName: data.PackageName, Tool: tool}
 		file := filepath.Join(output, "src", "main", "java", pkgPath, "tools", tool.Name+".java")
-		if err := g.generateTemplate("templates/java/stdio/src/main/java/tools/Tool.java.tmpl", file, td); err != nil {
+		if err := g.generateTemplate(ToolTemplate(g.GetLanguage()), file, td); err != nil {
 			return err
 		}
 	}
@@ -93,7 +77,7 @@ func (g *JavaGenerator) generateFromTemplates(output string, data *core.Template
 			Resource    core.Resource
 		}{PackageName: data.PackageName, Resource: res}
 		file := filepath.Join(output, "src", "main", "java", pkgPath, "resources", res.Name+".java")
-		if err := g.generateTemplate("templates/java/stdio/src/main/java/resources/Resource.java.tmpl", file, rd); err != nil {
+		if err := g.generateTemplate(ResourceTemplate(g.GetLanguage()), file, rd); err != nil {
 			return err
 		}
 	}
@@ -103,7 +87,7 @@ func (g *JavaGenerator) generateFromTemplates(output string, data *core.Template
 			Capability  core.Capability
 		}{PackageName: data.PackageName, Capability: cap}
 		file := filepath.Join(output, "src", "main", "java", pkgPath, "capabilities", cap.Name+".java")
-		if err := g.generateTemplate("templates/java/stdio/src/main/java/capabilities/Capability.java.tmpl", file, cd); err != nil {
+		if err := g.generateTemplate(CapabilityTemplate(g.GetLanguage()), file, cd); err != nil {
 			return err
 		}
 	}

--- a/internal/generators/node.go
+++ b/internal/generators/node.go
@@ -54,14 +54,9 @@ func (g *NodeGenerator) createDirectoryStructure(output string) error {
 }
 
 func (g *NodeGenerator) generateFromTemplates(output string, data *core.TemplateData) error {
-	templates := map[string]string{
-		"templates/node/stdio/package.json.tmpl":              "package.json",
-		"templates/node/stdio/src/index.js.tmpl":              "src/index.js",
-		"templates/node/stdio/src/handlers/mcp.js.tmpl":       "src/handlers/mcp.js",
-		"templates/node/stdio/src/resources/registry.js.tmpl": "src/resources/registry.js",
-		"templates/node/stdio/README.md.tmpl":                 "README.md",
-		"templates/node/stdio/configs/mcp-config.json.tmpl":   "configs/mcp-config.json",
-		"templates/node/stdio/examples/example.js.tmpl":       "examples/example.js",
+	templates, err := BaseTemplateMap(g.GetLanguage(), data)
+	if err != nil {
+		return err
 	}
 
 	for tPath, outPath := range templates {
@@ -70,24 +65,12 @@ func (g *NodeGenerator) generateFromTemplates(output string, data *core.Template
 		}
 	}
 
-	if data.Config.Docker {
-		dockerTemps := map[string]string{
-			"templates/node/stdio/Dockerfile.tmpl":   "Dockerfile",
-			"templates/node/stdio/dockerignore.tmpl": ".dockerignore",
-		}
-		for tPath, outPath := range dockerTemps {
-			if err := g.generateTemplate(tPath, filepath.Join(output, outPath), data); err != nil {
-				return err
-			}
-		}
-	}
-
 	for _, tool := range data.Config.Tools {
 		td := struct {
 			Tool core.Tool
 		}{Tool: tool}
 		file := filepath.Join(output, "src/tools", tool.Name+".js")
-		if err := g.generateTemplate("templates/node/stdio/src/tools/tool.js.tmpl", file, td); err != nil {
+		if err := g.generateTemplate(ToolTemplate(g.GetLanguage()), file, td); err != nil {
 			return err
 		}
 	}
@@ -97,7 +80,7 @@ func (g *NodeGenerator) generateFromTemplates(output string, data *core.Template
 			Resource core.Resource
 		}{Resource: res}
 		file := filepath.Join(output, "src/resources", res.Name+".js")
-		if err := g.generateTemplate("templates/node/stdio/src/resources/resource.js.tmpl", file, rd); err != nil {
+		if err := g.generateTemplate(ResourceTemplate(g.GetLanguage()), file, rd); err != nil {
 			return err
 		}
 	}
@@ -107,7 +90,7 @@ func (g *NodeGenerator) generateFromTemplates(output string, data *core.Template
 			Capability core.Capability
 		}{Capability: cap}
 		file := filepath.Join(output, "src/capabilities", cap.Name+".js")
-		if err := g.generateTemplate("templates/node/stdio/src/capabilities/capability.js.tmpl", file, cd); err != nil {
+		if err := g.generateTemplate(CapabilityTemplate(g.GetLanguage()), file, cd); err != nil {
 			return err
 		}
 	}

--- a/internal/generators/python.go
+++ b/internal/generators/python.go
@@ -54,46 +54,34 @@ func (g *PythonGenerator) createDirectoryStructure(output string) error {
 
 // generateFromTemplates renders all static and dynamic templates for the project.
 func (g *PythonGenerator) generateFromTemplates(output string, data *core.TemplateData) error {
-	templates := map[string]string{
-		"templates/python/stdio/src/main.py.tmpl":               "src/main.py",
-		"templates/python/stdio/src/handlers/mcp.py.tmpl":       "src/handlers/mcp.py",
-		"templates/python/stdio/src/resources/registry.py.tmpl": "src/resources/registry.py",
-		"templates/python/stdio/README.md.tmpl":                 "README.md",
-		"templates/python/stdio/configs/mcp-config.json.tmpl":   "configs/mcp-config.json",
-		"templates/python/stdio/examples/example.py.tmpl":       "examples/example.py",
+	templates, err := BaseTemplateMap(g.GetLanguage(), data)
+	if err != nil {
+		return err
 	}
 	if err := g.generateTemplateMap(output, templates, data); err != nil {
 		return err
 	}
 
-	if data.Config.Docker {
-		dockerTemps := map[string]string{
-			"templates/python/stdio/Dockerfile.tmpl":   "Dockerfile",
-			"templates/python/stdio/dockerignore.tmpl": ".dockerignore",
-		}
-		if err := g.generateTemplateMap(output, dockerTemps, data); err != nil {
-			return err
-		}
-	}
+	// Docker templates are included in BaseTemplateMap
 
 	toolConv := func(t core.Tool) (string, interface{}) {
 		return t.Name, struct{ Tool core.Tool }{Tool: t}
 	}
-	if err := generateEntities(g, output, "src/tools", "templates/python/stdio/src/tools/tool.py.tmpl", data.Config.Tools, toolConv); err != nil {
+	if err := generateEntities(g, output, "src/tools", ToolTemplate(g.GetLanguage()), data.Config.Tools, toolConv); err != nil {
 		return err
 	}
 
 	resConv := func(r core.Resource) (string, interface{}) {
 		return r.Name, struct{ Resource core.Resource }{Resource: r}
 	}
-	if err := generateEntities(g, output, "src/resources", "templates/python/stdio/src/resources/resource.py.tmpl", data.Config.Resources, resConv); err != nil {
+	if err := generateEntities(g, output, "src/resources", ResourceTemplate(g.GetLanguage()), data.Config.Resources, resConv); err != nil {
 		return err
 	}
 
 	capConv := func(c core.Capability) (string, interface{}) {
 		return c.Name, struct{ Capability core.Capability }{Capability: c}
 	}
-	if err := generateEntities(g, output, "src/capabilities", "templates/python/stdio/src/capabilities/capability.py.tmpl", data.Config.Capabilities, capConv); err != nil {
+	if err := generateEntities(g, output, "src/capabilities", CapabilityTemplate(g.GetLanguage()), data.Config.Capabilities, capConv); err != nil {
 		return err
 	}
 

--- a/internal/generators/template_utils_test.go
+++ b/internal/generators/template_utils_test.go
@@ -1,0 +1,45 @@
+package generators
+
+import (
+	"testing"
+
+	"github.com/aawadall/mcpcli/internal/core"
+)
+
+func TestBaseTemplateMap_Go(t *testing.T) {
+	cfg := &core.ProjectConfig{}
+	data := cfg.GetTemplateData()
+	m, err := BaseTemplateMap("go", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["templates/go/stdio/go.mod.tmpl"] == "" {
+		t.Errorf("expected go.mod template mapping")
+	}
+}
+
+func TestBaseTemplateMap_Docker(t *testing.T) {
+	cfg := &core.ProjectConfig{Docker: true}
+	data := cfg.GetTemplateData()
+	m, err := BaseTemplateMap("python", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := m["templates/python/stdio/Dockerfile.tmpl"]; !ok {
+		t.Errorf("expected docker template when docker enabled")
+	}
+}
+
+func TestBaseTemplateMap_Invalid(t *testing.T) {
+	cfg := &core.ProjectConfig{}
+	data := cfg.GetTemplateData()
+	if _, err := BaseTemplateMap("invalid", data); err == nil {
+		t.Error("expected error for invalid language")
+	}
+}
+
+func TestTemplateHelpers(t *testing.T) {
+	if ToolTemplate("go") == "" || ResourceTemplate("go") == "" || CapabilityTemplate("go") == "" {
+		t.Error("expected template helper paths for go")
+	}
+}

--- a/internal/generators/templates/utils.go
+++ b/internal/generators/templates/utils.go
@@ -1,0 +1,146 @@
+package generators
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/aawadall/mcpcli/internal/core"
+)
+
+// BaseTemplateMap returns a mapping of embedded template paths to their output
+// locations based on the generator language and configuration.
+func BaseTemplateMap(lang string, data *core.TemplateData) (map[string]string, error) {
+	switch lang {
+	case "go":
+		return goTemplateMap(data), nil
+	case "javascript":
+		return nodeTemplateMap(data), nil
+	case "python":
+		return pythonTemplateMap(data), nil
+	case "java":
+		return javaTemplateMap(data), nil
+	default:
+		return nil, fmt.Errorf("unsupported language: %s", lang)
+	}
+}
+
+func goTemplateMap(data *core.TemplateData) map[string]string {
+	m := map[string]string{
+		"templates/go/stdio/go.mod.tmpl":                           "go.mod",
+		"templates/go/stdio/cmd/server/main.go.tmpl":               filepath.Join("cmd", "server", "main.go"),
+		"templates/go/stdio/internal/handlers/mcp.go.tmpl":         filepath.Join("internal", "handlers", "mcp.go"),
+		"templates/go/stdio/internal/resources/filesystem.go.tmpl": filepath.Join("internal", "resources", "filesystem.go"),
+		"templates/go/stdio/internal/resources/registry.go.tmpl":   filepath.Join("internal", "resources", "registry.go"),
+		"templates/go/stdio/internal/tools/calculator.go.tmpl":     filepath.Join("internal", "tools", "calculator.go"),
+		"templates/go/stdio/pkg/mcp/client.go.tmpl":                filepath.Join("pkg", "mcp", "client.go"),
+		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                   filepath.Join("pkg", "mcp", "mcp.go"),
+		"templates/go/stdio/README.md.tmpl":                        "README.md",
+		"templates/go/stdio/configs/mcp-config.json.tmpl":          filepath.Join("configs", "mcp-config.json"),
+		"templates/go/stdio/examples/example.go.tmpl":              filepath.Join("examples", "example.go"),
+	}
+	if data.Config.Docker {
+		m["templates/go/stdio/Dockerfile.tmpl"] = "Dockerfile"
+		m["templates/go/stdio/dockerignore.tmpl"] = ".dockerignore"
+	}
+	return m
+}
+
+func nodeTemplateMap(data *core.TemplateData) map[string]string {
+	m := map[string]string{
+		"templates/node/stdio/package.json.tmpl":              "package.json",
+		"templates/node/stdio/src/index.js.tmpl":              filepath.Join("src", "index.js"),
+		"templates/node/stdio/src/handlers/mcp.js.tmpl":       filepath.Join("src", "handlers", "mcp.js"),
+		"templates/node/stdio/src/resources/registry.js.tmpl": filepath.Join("src", "resources", "registry.js"),
+		"templates/node/stdio/README.md.tmpl":                 "README.md",
+		"templates/node/stdio/configs/mcp-config.json.tmpl":   filepath.Join("configs", "mcp-config.json"),
+		"templates/node/stdio/examples/example.js.tmpl":       filepath.Join("examples", "example.js"),
+	}
+	if data.Config.Docker {
+		m["templates/node/stdio/Dockerfile.tmpl"] = "Dockerfile"
+		m["templates/node/stdio/dockerignore.tmpl"] = ".dockerignore"
+	}
+	return m
+}
+
+func pythonTemplateMap(data *core.TemplateData) map[string]string {
+	m := map[string]string{
+		"templates/python/stdio/src/main.py.tmpl":               filepath.Join("src", "main.py"),
+		"templates/python/stdio/src/handlers/mcp.py.tmpl":       filepath.Join("src", "handlers", "mcp.py"),
+		"templates/python/stdio/src/resources/registry.py.tmpl": filepath.Join("src", "resources", "registry.py"),
+		"templates/python/stdio/README.md.tmpl":                 "README.md",
+		"templates/python/stdio/configs/mcp-config.json.tmpl":   filepath.Join("configs", "mcp-config.json"),
+		"templates/python/stdio/examples/example.py.tmpl":       filepath.Join("examples", "example.py"),
+	}
+	if data.Config.Docker {
+		m["templates/python/stdio/Dockerfile.tmpl"] = "Dockerfile"
+		m["templates/python/stdio/dockerignore.tmpl"] = ".dockerignore"
+	}
+	return m
+}
+
+func javaTemplateMap(data *core.TemplateData) map[string]string {
+	pkgPath := filepath.Join(strings.Split(data.PackageName, ".")...)
+	m := map[string]string{
+		"templates/java/stdio/pom.xml.tmpl":                                "pom.xml",
+		"templates/java/stdio/src/main/java/Main.java.tmpl":                filepath.Join("src", "main", "java", pkgPath, "Main.java"),
+		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl": filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
+		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":  filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
+		"templates/java/stdio/README.md.tmpl":                              "README.md",
+		"templates/java/stdio/configs/mcp-config.json.tmpl":                filepath.Join("configs", "mcp-config.json"),
+		"templates/java/stdio/examples/Example.java.tmpl":                  filepath.Join("examples", "Example.java"),
+	}
+	if data.Config.Docker {
+		m["templates/java/stdio/Dockerfile.tmpl"] = "Dockerfile"
+		m["templates/java/stdio/dockerignore.tmpl"] = ".dockerignore"
+	}
+	return m
+}
+
+// ToolTemplate returns the template path for generating a single tool file.
+func ToolTemplate(lang string) string {
+	switch lang {
+	case "go":
+		return "templates/go/stdio/internal/tools/tool.go.tmpl"
+	case "javascript":
+		return "templates/node/stdio/src/tools/tool.js.tmpl"
+	case "python":
+		return "templates/python/stdio/src/tools/tool.py.tmpl"
+	case "java":
+		return "templates/java/stdio/src/main/java/tools/Tool.java.tmpl"
+	default:
+		return ""
+	}
+}
+
+// ResourceTemplate returns the template path for generating a single resource file.
+func ResourceTemplate(lang string) string {
+	switch lang {
+	case "go":
+		return "templates/go/stdio/internal/resources/resource.go.tmpl"
+	case "javascript":
+		return "templates/node/stdio/src/resources/resource.js.tmpl"
+	case "python":
+		return "templates/python/stdio/src/resources/resource.py.tmpl"
+	case "java":
+		return "templates/java/stdio/src/main/java/resources/Resource.java.tmpl"
+	default:
+		return ""
+	}
+}
+
+// CapabilityTemplate returns the template path for generating a single capability file.
+func CapabilityTemplate(lang string) string {
+	switch lang {
+	case "go":
+		return "templates/go/stdio/internal/capabilities/capability.go.tmpl"
+	case "javascript":
+		return "templates/node/stdio/src/capabilities/capability.js.tmpl"
+	case "python":
+		return "templates/python/stdio/src/capabilities/capability.py.tmpl"
+	case "java":
+		return "templates/java/stdio/src/main/java/capabilities/Capability.java.tmpl"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- centralize template path mappings in `BaseTemplateMap`
- refactor generators to use the new utilities
- update docs version number
- add unit tests for the new template utils

## Testing
- `go test ./... -cover` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68869072fde4832f853c08fb0b0e1990