### PR TITLE
Add language selector for docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -40,9 +40,28 @@ go build -o mcpcli ./cmd/mcpcli
                 <div class="step-number">3</div>
                 <h3>Develop</h3>
                 <p>Start building your MCP server:</p>
-                <div class="code-block">
+                <label for="lang-select" class="language-select">Language:</label>
+                <select id="lang-select" class="language-select">
+                    <option value="golang">Go</option>
+                    <option value="javascript">Node.js</option>
+                    <option value="python">Python</option>
+                    <option value="java">Java</option>
+                </select>
+                <div class="code-block lang-cmd" data-lang="golang">
 cd my-mcp-server
 go run cmd/server/main.go
+                </div>
+                <div class="code-block lang-cmd" data-lang="javascript" style="display:none">
+cd my-mcp-server
+npm start
+                </div>
+                <div class="code-block lang-cmd" data-lang="python" style="display:none">
+cd my-mcp-server
+python main.py
+                </div>
+                <div class="code-block lang-cmd" data-lang="java" style="display:none">
+cd my-mcp-server
+mvn spring-boot:run
                 </div>
             </div>
             <div class="step">
@@ -77,4 +96,17 @@ go run cmd/server/main.go
             </ul>
         </div>
     </div>
-</section> 
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const select = document.getElementById('lang-select');
+            const blocks = document.querySelectorAll('.lang-cmd');
+            if (select) {
+                select.addEventListener('change', function() {
+                    blocks.forEach(function(b) {
+                        b.style.display = b.dataset.lang === select.value ? 'block' : 'none';
+                    });
+                });
+            }
+        });
+    </script>
+</section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -166,6 +166,10 @@ header {
     overflow-x: auto;
 }
 
+.language-select {
+    margin-bottom: 0.5rem;
+}
+
 .steps {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/internal/generators/java.go
+++ b/internal/generators/java.go
@@ -21,6 +21,7 @@ func (g *JavaGenerator) GetLanguage() string { return "java" }
 
 func (g *JavaGenerator) GetSupportedTransports() []string { return []string{"stdio"} }
 
+// Generate scaffolds a Java project using the provided configuration.
 func (g *JavaGenerator) Generate(config *core.ProjectConfig) error {
 	data := config.GetTemplateData()
 	if err := g.createDirectoryStructure(config.Output, data.PackageName); err != nil {

--- a/internal/generators/node.go
+++ b/internal/generators/node.go
@@ -26,6 +26,7 @@ func (g *NodeGenerator) GetSupportedTransports() []string {
 	return []string{"stdio"}
 }
 
+// Generate scaffolds a Node.js project using the provided configuration.
 func (g *NodeGenerator) Generate(config *core.ProjectConfig) error {
 	data := config.GetTemplateData()
 	if err := g.createDirectoryStructure(config.Output); err != nil {


### PR DESCRIPTION
## Summary
- add instructions for multiple language targets
- style language selector dropdown
- document Node.js and Java generators

## Testing
- `go test ./... -cover` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6886c70bd5e4832fbabcf207cf841327