### PR TITLE
Refactor main command structure and add unit tests

### DIFF
--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/aawadall/mcpcli/internal/commands"
-	"github.com/spf13/cobra"
 )
 
 // version is the current release tag for the CLI.
@@ -13,32 +12,11 @@ var version = "0.4.1"
 
 func main() {
 	// Create the root command
-	rootCmd := makeRootCommand()
+	rootCmd := commands.MakeRootCommand(version)
 
 	// Execute the root command
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-// make root command
-func makeRootCommand() *cobra.Command {
-	rootCmd := &cobra.Command{
-		Use:     "mcpcli",
-		Short:   "A CLI tool for MCP (Model Context Protocol) development",
-		Long:    `mcpcli is a command-line tool for scaffolding, testing, and managing MCP servers across multiple languages.`,
-		Version: version,
-	}
-
-	// Add subcommands
-	rootCmd.AddCommand(commands.NewGenerateCmd())
-	rootCmd.AddCommand(commands.NewTestCmd())
-	// TODO: Add future commands
-
-	// Global flags
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
-	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress output")
-
-	return rootCmd
 }

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -12,6 +12,18 @@ import (
 var version = "0.4.1"
 
 func main() {
+	// Create the root command
+	rootCmd := makeRootCommand()
+
+	// Execute the root command
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// make root command
+func makeRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "mcpcli",
 		Short:   "A CLI tool for MCP (Model Context Protocol) development",
@@ -28,8 +40,5 @@ func main() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress output")
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	return rootCmd
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// make root command
+func MakeRootCommand(version string) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "mcpcli",
+		Short:   "A CLI tool for MCP (Model Context Protocol) development",
+		Long:    `mcpcli is a command-line tool for scaffolding, testing, and managing MCP servers across multiple languages.`,
+		Version: version,
+	}
+
+	// Add subcommands
+	rootCmd.AddCommand(NewGenerateCmd())
+	rootCmd.AddCommand(NewTestCmd())
+	// TODO: Add future commands
+
+	// Global flags
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress output")
+
+	return rootCmd
+}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -1,0 +1,59 @@
+package commands
+
+import "testing"
+
+// test make root command
+
+var version = "1.0.0" // Example version, replace with actual version if needed
+func TestMakeRootCommand(t *testing.T) {
+	rootCmd := MakeRootCommand(version)
+
+	if rootCmd.Use != "mcpcli" {
+		t.Errorf("expected Use to be 'mcpcli', got '%s'", rootCmd.Use)
+	}
+
+	if rootCmd.Short != "A CLI tool for MCP (Model Context Protocol) development" {
+		t.Errorf("expected Short description to match, got '%s'", rootCmd.Short)
+	}
+
+	if rootCmd.Version != version {
+		t.Errorf("expected version to be '%s', got '%s'", version, rootCmd.Version)
+	}
+
+	if len(rootCmd.Commands()) == 0 {
+		t.Error("expected at least one subcommand")
+	}
+}
+
+// Test added commands
+func TestAddedCommands(t *testing.T) {
+	rootCmd := MakeRootCommand(version)
+	if len(rootCmd.Commands()) < 2 {
+		t.Error("expected at least two subcommands (generate and test)")
+	}
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "generate" || cmd.Name() == "test" {
+			if cmd.Use == "" {
+				t.Errorf("expected command '%s' to have a valid use description", cmd.Name())
+			}
+		} else {
+			t.Errorf("unexpected command found: %s", cmd.Name())
+		}
+	}
+}
+
+// Test global flags
+func TestGlobalFlags(t *testing.T) {
+	rootCmd := MakeRootCommand(version)
+
+	verboseFlag := rootCmd.PersistentFlags().Lookup("verbose")
+	if verboseFlag == nil || verboseFlag.Name != "verbose" {
+		t.Error("expected global flag 'verbose' to be defined")
+	}
+
+	quietFlag := rootCmd.PersistentFlags().Lookup("quiet")
+	if quietFlag == nil || quietFlag.Name != "quiet" {
+		t.Error("expected global flag 'quiet' to be defined")
+	}
+}


### PR DESCRIPTION
This PR refactors the main command creation by introducing a new `MakeRootCommand` function for better organization and readability. Additionally, unit tests have been added to ensure the correctness of the command structure and global flags. This enhances code maintainability and test coverage.