### PR TITLE
Add methods to retrieve names for Tool, Resource, and Capability types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,16 +6,20 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/fatih/color v1.18.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.6.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -33,3 +33,18 @@ func IsValidResourceType(t string) bool {
 		return false
 	}
 }
+
+// GetName returns the name of the tool
+func (t Tool) GetName() string {
+	return t.Name
+}
+
+// GetName returns the name of the resource
+func (r Resource) GetName() string {
+	return r.Name
+}
+
+// GetName returns the name of the capability
+func (c Capability) GetName() string {
+	return c.Name
+}

--- a/internal/generators/node.go
+++ b/internal/generators/node.go
@@ -87,7 +87,7 @@ func (g *NodeGenerator) generateFromTemplates(output string, data *core.Template
 }
 
 // Generate Items
-func generateItems[T interface{ interface{ GetName() string } }](g *NodeGenerator, output, subDir string, items []T, templatePath string) error {
+func generateItems[T interface{ GetName() string }](g *NodeGenerator, output, subDir string, items []T, templatePath string) error {
 	for _, item := range items {
 		// create wrapper struct with the item
 		data := struct {

--- a/internal/generators/node.go
+++ b/internal/generators/node.go
@@ -86,7 +86,10 @@ func (g *NodeGenerator) generateFromTemplates(output string, data *core.Template
 	return nil
 }
 
-// Generate Items
+// generateItems creates files for a slice of items that implement the GetName() method.
+// It uses the specified template and writes the generated files to the given subdirectory
+// within the output directory. Each item's name, as returned by GetName(), is used to
+// determine the filename.
 func generateItems[T interface{ GetName() string }](g *NodeGenerator, output, subDir string, items []T, templatePath string) error {
 	for _, item := range items {
 		// create wrapper struct with the item

--- a/internal/generators/node_test.go
+++ b/internal/generators/node_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aawadall/mcpcli/internal/core"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNodeGenerator_GetLanguage(t *testing.T) {
@@ -55,4 +56,64 @@ func TestNodeGenerator_GenerateBasic(t *testing.T) {
 			t.Errorf("expected file %s to be a file, but it is a directory", f)
 		}
 	}
+}
+
+// Mock types for testing
+type mockTool struct {
+	Name string
+}
+
+func (m mockTool) GetName() string {
+	return m.Name
+}
+
+type mockResource struct {
+	Name string
+}
+
+func (m mockResource) GetName() string {
+	return m.Name
+}
+
+type mockCapability struct {
+	Name string
+}
+
+func (m mockCapability) GetName() string {
+	return m.Name
+}
+
+func TestGenerateItems_Logic_Only(t *testing.T) {
+	// Test the path generation logic
+	tools := []mockTool{{Name: "testTool"}}
+	output := "/project"
+	subDir := "src/tools"
+
+	for _, tool := range tools {
+		expectedPath := filepath.Join(output, subDir, tool.GetName()+".js")
+		assert.Equal(t, "/project/src/tools/testTool.js", expectedPath)
+	}
+
+	// Test the data structure creation
+	tool := mockTool{Name: "myTool"}
+	data := struct {
+		Item mockTool
+	}{Item: tool}
+
+	assert.Equal(t, "myTool", data.Item.GetName())
+}
+
+func TestTemplateDataStructure(t *testing.T) {
+	// Test that the wrapper struct works correctly
+	tool := mockTool{Name: "hammer"}
+	resource := mockResource{Name: "database"}
+	capability := mockCapability{Name: "read"}
+
+	toolData := struct{ Item mockTool }{Item: tool}
+	resourceData := struct{ Item mockResource }{Item: resource}
+	capabilityData := struct{ Item mockCapability }{Item: capability}
+
+	assert.Equal(t, "hammer", toolData.Item.GetName())
+	assert.Equal(t, "database", resourceData.Item.GetName())
+	assert.Equal(t, "read", capabilityData.Item.GetName())
 }


### PR DESCRIPTION
This PR introduces new methods to retrieve the names of Tool, Resource, and Capability types. Additionally, it refactors the code to streamline the generation of files for these types by utilizing a generic function for item generation. This improves code maintainability and readability.