### PR TITLE
Add table-driven generator tests

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -14,5 +14,5 @@ To check code coverage, run:
 go test ./internal/core -cover
 ```
 The test suite currently targets **mcpcli v0.4.1** and achieves over 85% coverage for the core package.
-
 Additional tests cover `internal/commands/test.go` to validate the test command behavior.
+Table-driven tests for all generators ensure consistent behavior across languages.

--- a/internal/generators/generator_table_test.go
+++ b/internal/generators/generator_table_test.go
@@ -1,0 +1,38 @@
+package generators
+
+import (
+	"testing"
+)
+
+// TestGenerators verifies common behavior for all language generators using
+// table-driven tests.
+func TestGenerators(t *testing.T) {
+	tests := []struct {
+		name       string
+		gen        Generator
+		language   string
+		transports []string
+	}{
+		{"go", NewGolangGenerator(), "go", []string{"stdio", "rest", "websocket"}},
+		{"java", NewJavaGenerator(), "java", []string{"stdio"}},
+		{"javascript", NewNodeGenerator(), "javascript", []string{"stdio"}},
+		{"python", NewPythonGenerator(), "python", []string{"stdio"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.gen.GetLanguage(); got != tt.language {
+				t.Errorf("expected language %s, got %s", tt.language, got)
+			}
+			gotTrans := tt.gen.GetSupportedTransports()
+			if len(gotTrans) != len(tt.transports) {
+				t.Fatalf("expected %d transports, got %d", len(tt.transports), len(gotTrans))
+			}
+			for i, tr := range tt.transports {
+				if gotTrans[i] != tr {
+					t.Errorf("expected transport %s, got %s", tr, gotTrans[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/generators/generator_table_test.go
+++ b/internal/generators/generator_table_test.go
@@ -29,8 +29,10 @@ func TestGenerators(t *testing.T) {
 				t.Fatalf("expected %d transports, got %d", len(tt.transports), len(gotTrans))
 			}
 			sort.Strings(gotTrans)
-			sort.Strings(tt.transports)
-			for i, tr := range tt.transports {
+			expectedTrans := make([]string, len(tt.transports))
+			copy(expectedTrans, tt.transports)
+			sort.Strings(expectedTrans)
+			for i, tr := range expectedTrans {
 				if gotTrans[i] != tr {
 					t.Errorf("expected transport %s, got %s", tr, gotTrans[i])
 				}

--- a/internal/generators/generator_table_test.go
+++ b/internal/generators/generator_table_test.go
@@ -28,6 +28,8 @@ func TestGenerators(t *testing.T) {
 			if len(gotTrans) != len(tt.transports) {
 				t.Fatalf("expected %d transports, got %d", len(tt.transports), len(gotTrans))
 			}
+			sort.Strings(gotTrans)
+			sort.Strings(tt.transports)
 			for i, tr := range tt.transports {
 				if gotTrans[i] != tr {
 					t.Errorf("expected transport %s, got %s", tr, gotTrans[i])


### PR DESCRIPTION
## Summary
- add table-driven tests covering each generator implementation
- mention generator tests in testing docs

## Testing
- `go test ./... -coverprofile=coverage.out` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888d44cf9f0832f9258b5a57c3f5f1d