### PR TITLE
Update action-gh-release to a specific commit version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         path: dist/
         
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@72f2c25
       with:
         files: |
           dist/*.tar.gz


### PR DESCRIPTION
This PR updates the `action-gh-release` action to a specific commit version (72f2c25) to ensure stability and consistency in the release process. This change will help avoid potential issues with future updates of the action.