### PR TITLE
Add flags to generate command and improve tests

### DIFF
--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -65,6 +65,13 @@ func NewGenerateCmd() *cobra.Command {
 	}
 
 	// Add flags
+	addFlags(cmd, opts)
+
+	return cmd
+}
+
+// Add flags to the generate command.
+func addFlags(cmd *cobra.Command, opts *GenerateOptions) {
 	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "MCP project name")
 	cmd.Flags().StringVarP(&opts.Language, "language", "l", "", "Programming language (e.g., golang, python, java)")
 	cmd.Flags().StringVarP(&opts.Transport, "transport", "t", "", "Transport method (e.g., stdio, rest, websocket)")
@@ -72,8 +79,6 @@ func NewGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.Examples, "examples", "e", false, "Include example resources and tools")
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output directory (default to project name)")
 	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Overwrite existing directory")
-
-	return cmd
 }
 
 // needsInteractiveMode checks if the options are incomplete and requires user input.

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -63,7 +63,7 @@ func TestAddFlags(t *testing.T) {
 	cmd := &cobra.Command{}
 	opts := &GenerateOptions{}
 
-	// BEGIN: Test adding flags
+	
 	addFlags(cmd, opts)
 
 	if cmd.Flags().Lookup("name") == nil {

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -87,7 +87,7 @@ func TestAddFlags(t *testing.T) {
 	if cmd.Flags().Lookup("force") == nil {
 		t.Fatal("expected 'force' flag to be added")
 	}
-	// END: Test adding flags
+	
 }
 
 func TestNewGenerateCmd(t *testing.T) {

--- a/internal/commands/generate_test.go
+++ b/internal/commands/generate_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"os"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNeedsInteractiveMode(t *testing.T) {
@@ -57,3 +59,47 @@ func TestSelectGenerator(t *testing.T) {
 		t.Fatal("expected error for unsupported language")
 	}
 }
+func TestAddFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	opts := &GenerateOptions{}
+
+	// BEGIN: Test adding flags
+	addFlags(cmd, opts)
+
+	if cmd.Flags().Lookup("name") == nil {
+		t.Fatal("expected 'name' flag to be added")
+	}
+	if cmd.Flags().Lookup("language") == nil {
+		t.Fatal("expected 'language' flag to be added")
+	}
+	if cmd.Flags().Lookup("transport") == nil {
+		t.Fatal("expected 'transport' flag to be added")
+	}
+	if cmd.Flags().Lookup("docker") == nil {
+		t.Fatal("expected 'docker' flag to be added")
+	}
+	if cmd.Flags().Lookup("examples") == nil {
+		t.Fatal("expected 'examples' flag to be added")
+	}
+	if cmd.Flags().Lookup("output") == nil {
+		t.Fatal("expected 'output' flag to be added")
+	}
+	if cmd.Flags().Lookup("force") == nil {
+		t.Fatal("expected 'force' flag to be added")
+	}
+	// END: Test adding flags
+}
+
+func TestNewGenerateCmd(t *testing.T) {
+	cmd := NewGenerateCmd()
+	if cmd.Use != "generate [name]" {
+		t.Fatalf("expected command use to be 'generate [name]', got %s", cmd.Use)
+	}
+	if len(cmd.Aliases) != 2 || cmd.Aliases[0] != "gen" || cmd.Aliases[1] != "g" {
+		t.Fatalf("expected aliases to be 'gen' and 'g', got %v", cmd.Aliases)
+	}
+	if cmd.Short != "Generate a new MCP server project" {
+		t.Fatalf("expected short description to match, got %s", cmd.Short)
+	}
+}
+


### PR DESCRIPTION
This PR adds flags to the generate command for better configuration options and enhances the test suite to ensure the flags are correctly added. Additionally, it verifies the command's properties in the tests.