### PR TITLE
Add HTTP and WebSocket templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and other languages. It generates ready-to-use MCP server templates with support for multiple transports, Docker, and example resources/tools.
 
-**Current Version:** v0.4.1 (latest release)
+**Current Version:** v0.4.2 (latest release)
 
 > Learn more about the Model Context Protocol at the [official introduction page](https://modelcontextprotocol.io/introduction).
 
@@ -114,7 +114,7 @@ A generated Node.js MCP server project includes:
 
 Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
 Recent additions include tests for `internal/commands/test.go` and error handling cases in `internal/generators/node_test.go` to ensure the CLI testing workflow behaves as expected.
-See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.1 (latest)**.
+See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.2 (latest)**.
 All contributions must maintain this minimum coverage level.
 
 ## Contributing

--- a/docs/features.html
+++ b/docs/features.html
@@ -23,7 +23,7 @@
     <div class="container">
         <h2 class="section-title">Features</h2>
         <p class="section-subtitle">Everything you need to build MCP servers quickly and efficiently</p>
-        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
         <div class="features-grid">
             <div class="feature-card">
                 <span class="badge-implemented">Implemented</span>
@@ -42,10 +42,10 @@
             </div>
             <div class="feature-card">
                 <span class="badge-implemented">Stdio</span>
-                <span class="badge-planned">REST, WebSocket (planned)</span>
+                <span class="badge-implemented">REST, WebSocket</span>
                 <div class="feature-icon">🔗</div>
                 <h3>Flexible Transports</h3>
-                <p>Stdio <span class="badge-implemented">(available)</span>, REST and WebSocket <span class="badge-planned">(planned)</span> transport methods for your server.</p>
+                <p>Stdio, REST and WebSocket <span class="badge-implemented">(available)</span> transport methods for your server.</p>
             </div>
             <div class="feature-card">
                 <span class="badge-implemented">Implemented</span>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -23,7 +23,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,10 +52,10 @@
             </div>
             <div class="feature-card">
                 <span class="badge-implemented">Stdio</span>
-                <span class="badge-planned">REST, WebSocket (planned)</span>
+                <span class="badge-implemented">REST, WebSocket</span>
                 <div class="feature-icon">🔗</div>
                 <h3>Flexible Transports</h3>
-                <p>Stdio <span class="badge-implemented">(available)</span>, REST and WebSocket <span class="badge-planned">(planned)</span> transport methods for your server.</p>
+                <p>Stdio, REST and WebSocket <span class="badge-implemented">(available)</span> transport methods for your server.</p>
             </div>
             <div class="feature-card">
                 <span class="badge-implemented">Implemented</span>
@@ -88,7 +88,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/internal/core/doc.go
+++ b/internal/core/doc.go
@@ -1,4 +1,4 @@
 // Package core defines configuration and data types used by mcpcli.
-// Version information (latest tag v0.4.1) is propagated through this package to templates.
+// Version information (latest tag v0.4.2) is propagated through this package to templates.
 // This ensures generated projects reference the latest published version.
 package core

--- a/internal/generators/generator_table_test.go
+++ b/internal/generators/generator_table_test.go
@@ -15,9 +15,9 @@ func TestGenerators(t *testing.T) {
 		transports []string
 	}{
 		{"go", NewGolangGenerator(), "go", []string{"stdio", "rest", "websocket"}},
-		{"java", NewJavaGenerator(), "java", []string{"stdio"}},
-		{"javascript", NewNodeGenerator(), "javascript", []string{"stdio"}},
-		{"python", NewPythonGenerator(), "python", []string{"stdio"}},
+		{"java", NewJavaGenerator(), "java", []string{"stdio", "rest", "websocket"}},
+		{"javascript", NewNodeGenerator(), "javascript", []string{"stdio", "rest", "websocket"}},
+		{"python", NewPythonGenerator(), "python", []string{"stdio", "rest", "websocket"}},
 	}
 
 	for _, tt := range tests {

--- a/internal/generators/java.go
+++ b/internal/generators/java.go
@@ -19,7 +19,9 @@ func NewJavaGenerator() *JavaGenerator { return &JavaGenerator{} }
 
 func (g *JavaGenerator) GetLanguage() string { return "java" }
 
-func (g *JavaGenerator) GetSupportedTransports() []string { return []string{"stdio"} }
+func (g *JavaGenerator) GetSupportedTransports() []string {
+	return []string{"stdio", "rest", "websocket"}
+}
 
 // Generate scaffolds a Java project using the provided configuration.
 func (g *JavaGenerator) Generate(config *core.ProjectConfig) error {

--- a/internal/generators/node.go
+++ b/internal/generators/node.go
@@ -26,7 +26,7 @@ func (g *NodeGenerator) GetLanguage() string {
 
 // GetSupportedTransports lists the supported transport mechanisms.
 func (g *NodeGenerator) GetSupportedTransports() []string {
-	return []string{"stdio"}
+	return []string{"stdio", "rest", "websocket"}
 }
 
 // Generate scaffolds a Node.js project using the provided configuration.

--- a/internal/generators/python.go
+++ b/internal/generators/python.go
@@ -21,7 +21,9 @@ func NewPythonGenerator() *PythonGenerator { return &PythonGenerator{} }
 func (g *PythonGenerator) GetLanguage() string { return "python" }
 
 // GetSupportedTransports lists the transports supported by the generator.
-func (g *PythonGenerator) GetSupportedTransports() []string { return []string{"stdio"} }
+func (g *PythonGenerator) GetSupportedTransports() []string {
+	return []string{"stdio", "rest", "websocket"}
+}
 
 // Generate scaffolds a Python project using the provided configuration.
 func (g *PythonGenerator) Generate(config *core.ProjectConfig) error {

--- a/internal/generators/templates/go/http/cmd/server/main.go.tmpl
+++ b/internal/generators/templates/go/http/cmd/server/main.go.tmpl
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "log"
+    "net/http"
+    "os"
+
+    "github.com/gorilla/mux"
+    "{{.ModuleName}}/internal/handlers"
+    "{{.ModuleName}}/pkg/mcp"
+)
+
+func main() {
+    fmt.Fprintf(os.Stderr, "Starting {{.Config.Name}} MCP Server (http mode)...\n")
+
+    server := mcp.NewServer()
+    handler := handlers.NewHandler()
+
+    // Register handlers
+    server.RegisterResourceHandler(handler.HandleListResources)
+    server.RegisterResourceReadHandler(handler.HandleReadResource)
+    server.RegisterToolHandler(handler.HandleListTools)
+    server.RegisterCallToolHandler(handler.HandleCallTool)
+
+    router := mux.NewRouter()
+    router.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+        var req mcp.Request
+        if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+            http.Error(w, err.Error(), http.StatusBadRequest)
+            return
+        }
+        res := server.HandleRequest(req)
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(res)
+    }).Methods(http.MethodPost)
+
+    log.Fatal(http.ListenAndServe(":8080", router))
+}

--- a/internal/generators/templates/go/stdio/go.mod.tmpl
+++ b/internal/generators/templates/go/stdio/go.mod.tmpl
@@ -5,4 +5,5 @@ go 1.22
 require (
     github.com/gorilla/mux v1.8.0
     {{if eq .Config.Transport "rest"}}github.com/gorilla/handlers v1.5.1{{end}}
+    {{if eq .Config.Transport "websocket"}}github.com/gorilla/websocket v1.5.0{{end}}
 )

--- a/internal/generators/templates/go/websocket/cmd/server/main.go.tmpl
+++ b/internal/generators/templates/go/websocket/cmd/server/main.go.tmpl
@@ -1,0 +1,58 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "log"
+    "net/http"
+    "os"
+
+    "github.com/gorilla/websocket"
+    "{{.ModuleName}}/internal/handlers"
+    "{{.ModuleName}}/pkg/mcp"
+)
+
+var upgrader = websocket.Upgrader{}
+
+func main() {
+    fmt.Fprintf(os.Stderr, "Starting {{.Config.Name}} MCP Server (websocket mode)...\n")
+
+    server := mcp.NewServer()
+    handler := handlers.NewHandler()
+
+    // Register handlers
+    server.RegisterResourceHandler(handler.HandleListResources)
+    server.RegisterResourceReadHandler(handler.HandleReadResource)
+    server.RegisterToolHandler(handler.HandleListTools)
+    server.RegisterCallToolHandler(handler.HandleCallTool)
+
+    http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+        conn, err := upgrader.Upgrade(w, r, nil)
+        if err != nil {
+            log.Printf("upgrade error: %v", err)
+            return
+        }
+        defer conn.Close()
+        for {
+            _, msg, err := conn.ReadMessage()
+            if err != nil {
+                log.Printf("read error: %v", err)
+                break
+            }
+            var req mcp.Request
+            if err := json.Unmarshal(msg, &req); err != nil {
+                log.Printf("json error: %v", err)
+                continue
+            }
+            res := server.HandleRequest(req)
+            resBytes, err := json.Marshal(res)
+            if err != nil {
+                log.Printf("json error: %v", err)
+                continue
+            }
+            conn.WriteMessage(websocket.TextMessage, resBytes)
+        }
+    })
+
+    log.Fatal(http.ListenAndServe(":8081", nil))
+}

--- a/internal/generators/templates/java/http/src/main/java/Main.java.tmpl
+++ b/internal/generators/templates/java/http/src/main/java/Main.java.tmpl
@@ -1,0 +1,38 @@
+package {{.PackageName}};
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+import java.io.*;
+import java.net.InetSocketAddress;
+import org.json.JSONObject;
+import {{.PackageName}}.handlers.MCPHandler;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        System.err.println("Starting {{.Config.Name}} MCP Server (http mode)...");
+        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        server.createContext("/mcp", new HttpHandler() {
+            public void handle(HttpExchange ex) throws IOException {
+                if (!"POST".equals(ex.getRequestMethod())) {
+                    ex.sendResponseHeaders(405, -1);
+                    return;
+                }
+                String body = new String(ex.getRequestBody().readAllBytes());
+                try {
+                    JSONObject req = new JSONObject(body);
+                    JSONObject res = MCPHandler.handleRequest(req);
+                    byte[] resp = res.toString().getBytes();
+                    ex.getResponseHeaders().add("Content-Type", "application/json");
+                    ex.sendResponseHeaders(200, resp.length);
+                    ex.getResponseBody().write(resp);
+                } catch (Exception e) {
+                    ex.sendResponseHeaders(400, -1);
+                } finally {
+                    ex.close();
+                }
+            }
+        });
+        server.start();
+    }
+}

--- a/internal/generators/templates/java/stdio/pom.xml.tmpl
+++ b/internal/generators/templates/java/stdio/pom.xml.tmpl
@@ -9,5 +9,12 @@
       <artifactId>json</artifactId>
       <version>20210307</version>
     </dependency>
+    {{if eq .Config.Transport "websocket"}}
+    <dependency>
+      <groupId>org.java-websocket</groupId>
+      <artifactId>Java-WebSocket</artifactId>
+      <version>1.5.3</version>
+    </dependency>
+    {{end}}
   </dependencies>
 </project>

--- a/internal/generators/templates/java/websocket/src/main/java/Main.java.tmpl
+++ b/internal/generators/templates/java/websocket/src/main/java/Main.java.tmpl
@@ -1,0 +1,45 @@
+package {{.PackageName}};
+
+import java.net.InetSocketAddress;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.json.JSONObject;
+import {{.PackageName}}.handlers.MCPHandler;
+
+public class Main extends WebSocketServer {
+    public Main() {
+        super(new InetSocketAddress(8081));
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {}
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {}
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        try {
+            JSONObject req = new JSONObject(message);
+            JSONObject res = MCPHandler.handleRequest(req);
+            conn.send(res.toString());
+        } catch (Exception e) {
+            System.err.println("Error processing message: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        System.err.println("WebSocket error: " + ex.getMessage());
+    }
+
+    @Override
+    public void onStart() {
+        System.err.println("Starting {{.Config.Name}} MCP Server (websocket mode)...");
+    }
+
+    public static void main(String[] args) {
+        new Main().start();
+    }
+}

--- a/internal/generators/templates/node/http/src/index.js.tmpl
+++ b/internal/generators/templates/node/http/src/index.js.tmpl
@@ -1,0 +1,29 @@
+import http from 'http';
+import { handleRequest } from './handlers/mcp.js';
+
+console.error('Starting {{.Config.Name}} MCP Server (http mode)...');
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end();
+  }
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    try {
+      const reqObj = JSON.parse(body);
+      const result = handleRequest(reqObj);
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(result));
+    } catch (err) {
+      console.error('Error handling request:', err.message);
+      res.statusCode = 400;
+      res.end();
+    }
+  });
+});
+
+server.listen(8080, () => {
+  console.error('HTTP server listening on 8080');
+});

--- a/internal/generators/templates/node/stdio/package.json.tmpl
+++ b/internal/generators/templates/node/stdio/package.json.tmpl
@@ -10,5 +10,6 @@
     "start": "node src/index.js",
     "test": "echo \"No test specified\" && exit 1",
     "build": "echo \"No build step defined\" && exit 1"
-  }
+  },
+  "dependencies": { {{if eq .Config.Transport "websocket"}}"ws": "^8.13.0"{{end}} }
 }

--- a/internal/generators/templates/node/websocket/src/index.js.tmpl
+++ b/internal/generators/templates/node/websocket/src/index.js.tmpl
@@ -1,0 +1,18 @@
+import { WebSocketServer } from 'ws';
+import { handleRequest } from './handlers/mcp.js';
+
+console.error('Starting {{.Config.Name}} MCP Server (websocket mode)...');
+
+const wss = new WebSocketServer({ port: 8081 });
+
+wss.on('connection', ws => {
+  ws.on('message', message => {
+    try {
+      const reqObj = JSON.parse(message);
+      const res = handleRequest(reqObj);
+      ws.send(JSON.stringify(res));
+    } catch (err) {
+      console.error('Error handling message:', err.message);
+    }
+  });
+});

--- a/internal/generators/templates/python/http/src/main.py.tmpl
+++ b/internal/generators/templates/python/http/src/main.py.tmpl
@@ -1,0 +1,23 @@
+import sys
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from handlers.mcp import handle_request
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode('utf-8')
+        try:
+            req = json.loads(body)
+            res = handle_request(req)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode())
+        except Exception as e:
+            print(f'Error handling request: {e}', file=sys.stderr)
+            self.send_response(400)
+            self.end_headers()
+
+print(f"Starting {{ .Config.Name }} MCP Server (http mode)...", file=sys.stderr)
+HTTPServer(('localhost', 8080), Handler).serve_forever()

--- a/internal/generators/templates/python/websocket/src/main.py.tmpl
+++ b/internal/generators/templates/python/websocket/src/main.py.tmpl
@@ -1,0 +1,22 @@
+import asyncio
+import json
+import sys
+import websockets
+from handlers.mcp import handle_request
+
+async def handler(ws):
+    async for message in ws:
+        try:
+            req = json.loads(message)
+            res = handle_request(req)
+            await ws.send(json.dumps(res))
+        except Exception as e:
+            print(f'Error handling message: {e}', file=sys.stderr)
+
+async def main():
+    print(f"Starting {{ .Config.Name }} MCP Server (websocket mode)...", file=sys.stderr)
+    async with websockets.serve(handler, 'localhost', 8081):
+        await asyncio.Future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/internal/generators/templates/utils.go
+++ b/internal/generators/templates/utils.go
@@ -27,17 +27,17 @@ func BaseTemplateMap(lang string, data *core.TemplateData) (map[string]string, e
 
 func goTemplateMap(data *core.TemplateData) map[string]string {
 	m := map[string]string{
-		"templates/go/stdio/go.mod.tmpl":                           "go.mod",
-		"templates/go/stdio/cmd/server/main.go.tmpl":               filepath.Join("cmd", "server", "main.go"),
-		"templates/go/stdio/internal/handlers/mcp.go.tmpl":         filepath.Join("internal", "handlers", "mcp.go"),
-		"templates/go/stdio/internal/resources/filesystem.go.tmpl": filepath.Join("internal", "resources", "filesystem.go"),
-		"templates/go/stdio/internal/resources/registry.go.tmpl":   filepath.Join("internal", "resources", "registry.go"),
-		"templates/go/stdio/internal/tools/calculator.go.tmpl":     filepath.Join("internal", "tools", "calculator.go"),
-		"templates/go/stdio/pkg/mcp/client.go.tmpl":                filepath.Join("pkg", "mcp", "client.go"),
-		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                   filepath.Join("pkg", "mcp", "mcp.go"),
-		"templates/go/stdio/README.md.tmpl":                        "README.md",
-		"templates/go/stdio/configs/mcp-config.json.tmpl":          filepath.Join("configs", "mcp-config.json"),
-		"templates/go/stdio/examples/example.go.tmpl":              filepath.Join("examples", "example.go"),
+		"templates/go/stdio/go.mod.tmpl":                                              "go.mod",
+		fmt.Sprintf("templates/go/%s/cmd/server/main.go.tmpl", data.Config.Transport): filepath.Join("cmd", "server", "main.go"),
+		"templates/go/stdio/internal/handlers/mcp.go.tmpl":                            filepath.Join("internal", "handlers", "mcp.go"),
+		"templates/go/stdio/internal/resources/filesystem.go.tmpl":                    filepath.Join("internal", "resources", "filesystem.go"),
+		"templates/go/stdio/internal/resources/registry.go.tmpl":                      filepath.Join("internal", "resources", "registry.go"),
+		"templates/go/stdio/internal/tools/calculator.go.tmpl":                        filepath.Join("internal", "tools", "calculator.go"),
+		"templates/go/stdio/pkg/mcp/client.go.tmpl":                                   filepath.Join("pkg", "mcp", "client.go"),
+		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                                      filepath.Join("pkg", "mcp", "mcp.go"),
+		"templates/go/stdio/README.md.tmpl":                                           "README.md",
+		"templates/go/stdio/configs/mcp-config.json.tmpl":                             filepath.Join("configs", "mcp-config.json"),
+		"templates/go/stdio/examples/example.go.tmpl":                                 filepath.Join("examples", "example.go"),
 	}
 	if data.Config.Docker {
 		m["templates/go/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -48,13 +48,13 @@ func goTemplateMap(data *core.TemplateData) map[string]string {
 
 func nodeTemplateMap(data *core.TemplateData) map[string]string {
 	m := map[string]string{
-		"templates/node/stdio/package.json.tmpl":              "package.json",
-		"templates/node/stdio/src/index.js.tmpl":              filepath.Join("src", "index.js"),
-		"templates/node/stdio/src/handlers/mcp.js.tmpl":       filepath.Join("src", "handlers", "mcp.js"),
-		"templates/node/stdio/src/resources/registry.js.tmpl": filepath.Join("src", "resources", "registry.js"),
-		"templates/node/stdio/README.md.tmpl":                 "README.md",
-		"templates/node/stdio/configs/mcp-config.json.tmpl":   filepath.Join("configs", "mcp-config.json"),
-		"templates/node/stdio/examples/example.js.tmpl":       filepath.Join("examples", "example.js"),
+		"templates/node/stdio/package.json.tmpl":                                  "package.json",
+		fmt.Sprintf("templates/node/%s/src/index.js.tmpl", data.Config.Transport): filepath.Join("src", "index.js"),
+		"templates/node/stdio/src/handlers/mcp.js.tmpl":                           filepath.Join("src", "handlers", "mcp.js"),
+		"templates/node/stdio/src/resources/registry.js.tmpl":                     filepath.Join("src", "resources", "registry.js"),
+		"templates/node/stdio/README.md.tmpl":                                     "README.md",
+		"templates/node/stdio/configs/mcp-config.json.tmpl":                       filepath.Join("configs", "mcp-config.json"),
+		"templates/node/stdio/examples/example.js.tmpl":                           filepath.Join("examples", "example.js"),
 	}
 	if data.Config.Docker {
 		m["templates/node/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -65,12 +65,12 @@ func nodeTemplateMap(data *core.TemplateData) map[string]string {
 
 func pythonTemplateMap(data *core.TemplateData) map[string]string {
 	m := map[string]string{
-		"templates/python/stdio/src/main.py.tmpl":               filepath.Join("src", "main.py"),
-		"templates/python/stdio/src/handlers/mcp.py.tmpl":       filepath.Join("src", "handlers", "mcp.py"),
-		"templates/python/stdio/src/resources/registry.py.tmpl": filepath.Join("src", "resources", "registry.py"),
-		"templates/python/stdio/README.md.tmpl":                 "README.md",
-		"templates/python/stdio/configs/mcp-config.json.tmpl":   filepath.Join("configs", "mcp-config.json"),
-		"templates/python/stdio/examples/example.py.tmpl":       filepath.Join("examples", "example.py"),
+		fmt.Sprintf("templates/python/%s/src/main.py.tmpl", data.Config.Transport): filepath.Join("src", "main.py"),
+		"templates/python/stdio/src/handlers/mcp.py.tmpl":                          filepath.Join("src", "handlers", "mcp.py"),
+		"templates/python/stdio/src/resources/registry.py.tmpl":                    filepath.Join("src", "resources", "registry.py"),
+		"templates/python/stdio/README.md.tmpl":                                    "README.md",
+		"templates/python/stdio/configs/mcp-config.json.tmpl":                      filepath.Join("configs", "mcp-config.json"),
+		"templates/python/stdio/examples/example.py.tmpl":                          filepath.Join("examples", "example.py"),
 	}
 	if data.Config.Docker {
 		m["templates/python/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -82,13 +82,13 @@ func pythonTemplateMap(data *core.TemplateData) map[string]string {
 func javaTemplateMap(data *core.TemplateData) map[string]string {
 	pkgPath := filepath.Join(strings.Split(data.PackageName, ".")...)
 	m := map[string]string{
-		"templates/java/stdio/pom.xml.tmpl":                                "pom.xml",
-		"templates/java/stdio/src/main/java/Main.java.tmpl":                filepath.Join("src", "main", "java", pkgPath, "Main.java"),
-		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl": filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
-		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":  filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
-		"templates/java/stdio/README.md.tmpl":                              "README.md",
-		"templates/java/stdio/configs/mcp-config.json.tmpl":                filepath.Join("configs", "mcp-config.json"),
-		"templates/java/stdio/examples/Example.java.tmpl":                  filepath.Join("examples", "Example.java"),
+		"templates/java/stdio/pom.xml.tmpl":                                                  "pom.xml",
+		fmt.Sprintf("templates/java/%s/src/main/java/Main.java.tmpl", data.Config.Transport): filepath.Join("src", "main", "java", pkgPath, "Main.java"),
+		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl":                   filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
+		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":                    filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
+		"templates/java/stdio/README.md.tmpl":                                                "README.md",
+		"templates/java/stdio/configs/mcp-config.json.tmpl":                                  filepath.Join("configs", "mcp-config.json"),
+		"templates/java/stdio/examples/Example.java.tmpl":                                    filepath.Join("examples", "Example.java"),
 	}
 	if data.Config.Docker {
 		m["templates/java/stdio/Dockerfile.tmpl"] = "Dockerfile"


### PR DESCRIPTION
## Summary
- add HTTP and WebSocket server templates for Go, Node.js, Python and Java
- include transport-aware template mapping and dependencies
- mark REST and WebSocket transport as implemented in docs
- update version references to v0.4.2

## Testing
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_688b803def24832fa5a90791c41cf562