### PR TITLE
Add HTTP/WebSocket workflow and version sync

### DIFF
--- a/.github/workflows/http-ws-test.yml
+++ b/.github/workflows/http-ws-test.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Install websocat
         run: |
-          go install github.com/vi/websocat/cmd/websocat@v1.11.0
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          sudo apt-get update
+          sudo apt-get install -y websocat
 
       - name: Build CLI
         run: go build -o mcpcli ./cmd/mcpcli

--- a/.github/workflows/http-ws-test.yml
+++ b/.github/workflows/http-ws-test.yml
@@ -1,0 +1,82 @@
+name: HTTP and WebSocket Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.7'
+
+      - name: Install websocat
+        run: |
+          go install github.com/vi/websocat/cmd/websocat@v1.11.0
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Build CLI
+        run: go build -o mcpcli ./cmd/mcpcli
+
+      - name: Generate HTTP server
+        run: |
+          ./mcpcli generate http-server \
+            --language golang \
+            --transport rest \
+            --output ./http-server \
+            --force
+
+      - name: Build HTTP server
+        run: |
+          cd http-server
+          go mod tidy
+          go build ./...
+
+      - name: Start HTTP server
+        run: |
+          cd http-server/cmd/server
+          go build -o server .
+          ./server &
+          echo $! > /tmp/http_pid
+          sleep 2
+
+      - name: Test HTTP server
+        run: curl -X POST -d '{"method":"tools/list","id":1}' http://localhost:8080/mcp
+
+      - name: Stop HTTP server
+        run: kill $(cat /tmp/http_pid)
+
+      - name: Generate WebSocket server
+        run: |
+          ./mcpcli generate ws-server \
+            --language golang \
+            --transport websocket \
+            --output ./ws-server \
+            --force
+
+      - name: Build WebSocket server
+        run: |
+          cd ws-server
+          go mod tidy
+          go build ./...
+
+      - name: Start WebSocket server
+        run: |
+          cd ws-server/cmd/server
+          go build -o server .
+          ./server &
+          echo $! > /tmp/ws_pid
+          sleep 2
+
+      - name: Test WebSocket server
+        run: echo '{"method":"tools/list","id":1}' | websocat ws://localhost:8081/ws
+
+      - name: Stop WebSocket server
+        run: kill $(cat /tmp/ws_pid)

--- a/.github/workflows/http-ws-test.yml
+++ b/.github/workflows/http-ws-test.yml
@@ -19,8 +19,9 @@ jobs:
 
       - name: Install websocat
         run: |
-          sudo apt-get update
-          sudo apt-get install -y websocat
+          curl -L https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl -o websocat
+          chmod +x websocat
+          sudo mv websocat /usr/local/bin/websocat
 
       - name: Build CLI
         run: go build -o mcpcli ./cmd/mcpcli

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A CLI tool to scaffold Model Context Protocol (MCP) server projects in Go and other languages. It generates ready-to-use MCP server templates with support for multiple transports, Docker, and example resources/tools.
 
-**Current Version:** v0.4.2 (latest release)
+**Current Version:** v0.4.1 (latest release)
 
 > Learn more about the Model Context Protocol at the [official introduction page](https://modelcontextprotocol.io/introduction).
 
@@ -114,7 +114,7 @@ A generated Node.js MCP server project includes:
 
 Run `go test ./... -cover` to execute the unit tests. Overall coverage should remain above 85%.
 Recent additions include tests for `internal/commands/test.go` and error handling cases in `internal/generators/node_test.go` to ensure the CLI testing workflow behaves as expected.
-See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.2 (latest)**.
+See [the testing guide](doc/testing.md) for more details on running the tests for **mcpcli v0.4.1 (latest)**.
 All contributions must maintain this minimum coverage level.
 
 ## Contributing

--- a/cmd/mcpcli/main.go
+++ b/cmd/mcpcli/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 // version is the current release tag for the CLI.
-var version = "0.4.2"
+var version = "0.4.1"
 
 func main() {
 	// Create the root command

--- a/docs/features.html
+++ b/docs/features.html
@@ -23,7 +23,7 @@
     <div class="container">
         <h2 class="section-title">Features</h2>
         <p class="section-subtitle">Everything you need to build MCP servers quickly and efficiently</p>
-        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
         <div class="features-grid">
             <div class="feature-card">
                 <span class="badge-implemented">Implemented</span>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -23,7 +23,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -88,7 +88,7 @@
     <div class="container">
         <h2 class="section-title">Getting Started</h2>
         <p class="section-subtitle">Get up and running in minutes</p>
-        <p><strong>Version:</strong> v0.4.2 (latest release)</p>
+        <p><strong>Version:</strong> v0.4.1 (latest release)</p>
         <div class="steps">
             <div class="step">
                 <div class="step-number">1</div>

--- a/internal/commands/generate_validate_test.go
+++ b/internal/commands/generate_validate_test.go
@@ -11,6 +11,16 @@ func TestValidateOptions(t *testing.T) {
 		t.Fatalf("valid options returned error: %v", err)
 	}
 
+	opts.Transport = "rest"
+	if err := handlers.ValidateGenerateOptions(opts); err != nil {
+		t.Fatalf("rest should be valid: %v", err)
+	}
+
+	opts.Transport = "websocket"
+	if err := handlers.ValidateGenerateOptions(opts); err != nil {
+		t.Fatalf("websocket should be valid: %v", err)
+	}
+
 	opts.Language = "invalid"
 	if err := handlers.ValidateGenerateOptions(opts); err == nil {
 		t.Fatal("expected error for invalid language")

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -15,7 +15,7 @@ import (
 func writeTempConfig(t *testing.T, dir string) string {
 	cfg := &core.MCPConfig{
 		Name:      "test",
-		Version:   "0.4.2",
+		Version:   "0.4.1",
 		Transport: core.Transport{Type: "stdio"},
 	}
 	data, err := json.Marshal(cfg)
@@ -87,7 +87,7 @@ func TestLoadMCPConfig_Valid(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Direct MCPConfig
-	cfg := &core.MCPConfig{Name: "direct", Version: "0.4.2"}
+	cfg := &core.MCPConfig{Name: "direct", Version: "0.4.1"}
 	data, _ := json.Marshal(cfg)
 	direct := filepath.Join(tmpDir, "direct.json")
 	if err := os.WriteFile(direct, data, 0644); err != nil {

--- a/internal/core/doc.go
+++ b/internal/core/doc.go
@@ -1,4 +1,4 @@
 // Package core defines configuration and data types used by mcpcli.
-// Version information (latest tag v0.4.2) is propagated through this package to templates.
+// Version information (latest tag v0.4.1) is propagated through this package to templates.
 // This ensures generated projects reference the latest published version.
 package core

--- a/internal/core/projectconfig.go
+++ b/internal/core/projectconfig.go
@@ -22,7 +22,7 @@ type ProjectConfig struct {
 // NewProjectConfig creates a new project configuration with defaults
 func NewProjectConfig() *ProjectConfig {
 	return &ProjectConfig{
-		Version:   "0.4.2",
+		Version:   "0.4.1",
 		CreatedAt: time.Now(),
 	}
 }

--- a/internal/generators/templates/utils.go
+++ b/internal/generators/templates/utils.go
@@ -26,18 +26,22 @@ func BaseTemplateMap(lang string, data *core.TemplateData) (map[string]string, e
 }
 
 func goTemplateMap(data *core.TemplateData) map[string]string {
+	transport := data.Config.Transport
+	if transport == "rest" {
+		transport = "http"
+	}
 	m := map[string]string{
-		"templates/go/stdio/go.mod.tmpl":                                              "go.mod",
-		fmt.Sprintf("templates/go/%s/cmd/server/main.go.tmpl", data.Config.Transport): filepath.Join("cmd", "server", "main.go"),
-		"templates/go/stdio/internal/handlers/mcp.go.tmpl":                            filepath.Join("internal", "handlers", "mcp.go"),
-		"templates/go/stdio/internal/resources/filesystem.go.tmpl":                    filepath.Join("internal", "resources", "filesystem.go"),
-		"templates/go/stdio/internal/resources/registry.go.tmpl":                      filepath.Join("internal", "resources", "registry.go"),
-		"templates/go/stdio/internal/tools/calculator.go.tmpl":                        filepath.Join("internal", "tools", "calculator.go"),
-		"templates/go/stdio/pkg/mcp/client.go.tmpl":                                   filepath.Join("pkg", "mcp", "client.go"),
-		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                                      filepath.Join("pkg", "mcp", "mcp.go"),
-		"templates/go/stdio/README.md.tmpl":                                           "README.md",
-		"templates/go/stdio/configs/mcp-config.json.tmpl":                             filepath.Join("configs", "mcp-config.json"),
-		"templates/go/stdio/examples/example.go.tmpl":                                 filepath.Join("examples", "example.go"),
+		"templates/go/stdio/go.mod.tmpl":                                  "go.mod",
+		fmt.Sprintf("templates/go/%s/cmd/server/main.go.tmpl", transport): filepath.Join("cmd", "server", "main.go"),
+		"templates/go/stdio/internal/handlers/mcp.go.tmpl":                filepath.Join("internal", "handlers", "mcp.go"),
+		"templates/go/stdio/internal/resources/filesystem.go.tmpl":        filepath.Join("internal", "resources", "filesystem.go"),
+		"templates/go/stdio/internal/resources/registry.go.tmpl":          filepath.Join("internal", "resources", "registry.go"),
+		"templates/go/stdio/internal/tools/calculator.go.tmpl":            filepath.Join("internal", "tools", "calculator.go"),
+		"templates/go/stdio/pkg/mcp/client.go.tmpl":                       filepath.Join("pkg", "mcp", "client.go"),
+		"templates/go/stdio/pkg/mcp/mcp.go.tmpl":                          filepath.Join("pkg", "mcp", "mcp.go"),
+		"templates/go/stdio/README.md.tmpl":                               "README.md",
+		"templates/go/stdio/configs/mcp-config.json.tmpl":                 filepath.Join("configs", "mcp-config.json"),
+		"templates/go/stdio/examples/example.go.tmpl":                     filepath.Join("examples", "example.go"),
 	}
 	if data.Config.Docker {
 		m["templates/go/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -47,14 +51,18 @@ func goTemplateMap(data *core.TemplateData) map[string]string {
 }
 
 func nodeTemplateMap(data *core.TemplateData) map[string]string {
+	transport := data.Config.Transport
+	if transport == "rest" {
+		transport = "http"
+	}
 	m := map[string]string{
-		"templates/node/stdio/package.json.tmpl":                                  "package.json",
-		fmt.Sprintf("templates/node/%s/src/index.js.tmpl", data.Config.Transport): filepath.Join("src", "index.js"),
-		"templates/node/stdio/src/handlers/mcp.js.tmpl":                           filepath.Join("src", "handlers", "mcp.js"),
-		"templates/node/stdio/src/resources/registry.js.tmpl":                     filepath.Join("src", "resources", "registry.js"),
-		"templates/node/stdio/README.md.tmpl":                                     "README.md",
-		"templates/node/stdio/configs/mcp-config.json.tmpl":                       filepath.Join("configs", "mcp-config.json"),
-		"templates/node/stdio/examples/example.js.tmpl":                           filepath.Join("examples", "example.js"),
+		"templates/node/stdio/package.json.tmpl":                      "package.json",
+		fmt.Sprintf("templates/node/%s/src/index.js.tmpl", transport): filepath.Join("src", "index.js"),
+		"templates/node/stdio/src/handlers/mcp.js.tmpl":               filepath.Join("src", "handlers", "mcp.js"),
+		"templates/node/stdio/src/resources/registry.js.tmpl":         filepath.Join("src", "resources", "registry.js"),
+		"templates/node/stdio/README.md.tmpl":                         "README.md",
+		"templates/node/stdio/configs/mcp-config.json.tmpl":           filepath.Join("configs", "mcp-config.json"),
+		"templates/node/stdio/examples/example.js.tmpl":               filepath.Join("examples", "example.js"),
 	}
 	if data.Config.Docker {
 		m["templates/node/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -64,13 +72,17 @@ func nodeTemplateMap(data *core.TemplateData) map[string]string {
 }
 
 func pythonTemplateMap(data *core.TemplateData) map[string]string {
+	transport := data.Config.Transport
+	if transport == "rest" {
+		transport = "http"
+	}
 	m := map[string]string{
-		fmt.Sprintf("templates/python/%s/src/main.py.tmpl", data.Config.Transport): filepath.Join("src", "main.py"),
-		"templates/python/stdio/src/handlers/mcp.py.tmpl":                          filepath.Join("src", "handlers", "mcp.py"),
-		"templates/python/stdio/src/resources/registry.py.tmpl":                    filepath.Join("src", "resources", "registry.py"),
-		"templates/python/stdio/README.md.tmpl":                                    "README.md",
-		"templates/python/stdio/configs/mcp-config.json.tmpl":                      filepath.Join("configs", "mcp-config.json"),
-		"templates/python/stdio/examples/example.py.tmpl":                          filepath.Join("examples", "example.py"),
+		fmt.Sprintf("templates/python/%s/src/main.py.tmpl", transport): filepath.Join("src", "main.py"),
+		"templates/python/stdio/src/handlers/mcp.py.tmpl":              filepath.Join("src", "handlers", "mcp.py"),
+		"templates/python/stdio/src/resources/registry.py.tmpl":        filepath.Join("src", "resources", "registry.py"),
+		"templates/python/stdio/README.md.tmpl":                        "README.md",
+		"templates/python/stdio/configs/mcp-config.json.tmpl":          filepath.Join("configs", "mcp-config.json"),
+		"templates/python/stdio/examples/example.py.tmpl":              filepath.Join("examples", "example.py"),
 	}
 	if data.Config.Docker {
 		m["templates/python/stdio/Dockerfile.tmpl"] = "Dockerfile"
@@ -81,14 +93,18 @@ func pythonTemplateMap(data *core.TemplateData) map[string]string {
 
 func javaTemplateMap(data *core.TemplateData) map[string]string {
 	pkgPath := filepath.Join(strings.Split(data.PackageName, ".")...)
+	transport := data.Config.Transport
+	if transport == "rest" {
+		transport = "http"
+	}
 	m := map[string]string{
-		"templates/java/stdio/pom.xml.tmpl":                                                  "pom.xml",
-		fmt.Sprintf("templates/java/%s/src/main/java/Main.java.tmpl", data.Config.Transport): filepath.Join("src", "main", "java", pkgPath, "Main.java"),
-		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl":                   filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
-		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":                    filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
-		"templates/java/stdio/README.md.tmpl":                                                "README.md",
-		"templates/java/stdio/configs/mcp-config.json.tmpl":                                  filepath.Join("configs", "mcp-config.json"),
-		"templates/java/stdio/examples/Example.java.tmpl":                                    filepath.Join("examples", "Example.java"),
+		"templates/java/stdio/pom.xml.tmpl":                                      "pom.xml",
+		fmt.Sprintf("templates/java/%s/src/main/java/Main.java.tmpl", transport): filepath.Join("src", "main", "java", pkgPath, "Main.java"),
+		"templates/java/stdio/src/main/java/handlers/MCPHandler.java.tmpl":       filepath.Join("src", "main", "java", pkgPath, "handlers", "MCPHandler.java"),
+		"templates/java/stdio/src/main/java/resources/Registry.java.tmpl":        filepath.Join("src", "main", "java", pkgPath, "resources", "Registry.java"),
+		"templates/java/stdio/README.md.tmpl":                                    "README.md",
+		"templates/java/stdio/configs/mcp-config.json.tmpl":                      filepath.Join("configs", "mcp-config.json"),
+		"templates/java/stdio/examples/Example.java.tmpl":                        filepath.Join("examples", "Example.java"),
 	}
 	if data.Config.Docker {
 		m["templates/java/stdio/Dockerfile.tmpl"] = "Dockerfile"

--- a/internal/generators/templates/utils_test.go
+++ b/internal/generators/templates/utils_test.go
@@ -35,3 +35,23 @@ func TestTemplateHelpers(t *testing.T) {
 		}
 	}
 }
+
+func TestBaseTemplateMapRestTransport(t *testing.T) {
+	cfg := &core.ProjectConfig{Transport: "rest"}
+	data := cfg.GetTemplateData()
+	expected := map[string]string{
+		"go":         "templates/go/http/cmd/server/main.go.tmpl",
+		"javascript": "templates/node/http/src/index.js.tmpl",
+		"python":     "templates/python/http/src/main.py.tmpl",
+		"java":       "templates/java/http/src/main/java/Main.java.tmpl",
+	}
+	for lang, path := range expected {
+		m, err := BaseTemplateMap(lang, data)
+		if err != nil {
+			t.Fatalf("map for %s: %v", lang, err)
+		}
+		if _, ok := m[path]; !ok {
+			t.Errorf("expected %s to map to %s", lang, path)
+		}
+	}
+}

--- a/internal/handlers/generate.go
+++ b/internal/handlers/generate.go
@@ -34,7 +34,7 @@ func ValidateGenerateOptions(opts *GenerateOptions) error {
 	if !contains(validLanguages, opts.Language) {
 		return fmt.Errorf("invalid language: %s, valid options are: %v", opts.Language, validLanguages)
 	}
-	validTransports := []string{"stdio"}
+	validTransports := []string{"stdio", "rest", "websocket"}
 	if !contains(validTransports, opts.Transport) {
 		return fmt.Errorf("invalid transport: %s, valid options are: %v", opts.Transport, validTransports)
 	}

--- a/internal/handlers/generate_test.go
+++ b/internal/handlers/generate_test.go
@@ -10,11 +10,14 @@ import (
 )
 
 func TestValidateGenerateOptions(t *testing.T) {
-	opts := &GenerateOptions{Name: "proj", Language: "golang", Transport: "stdio"}
-	if err := ValidateGenerateOptions(opts); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	transports := []string{"stdio", "rest", "websocket"}
+	for _, tr := range transports {
+		opts := &GenerateOptions{Name: "proj", Language: "golang", Transport: tr}
+		if err := ValidateGenerateOptions(opts); err != nil {
+			t.Fatalf("%s should be valid: %v", tr, err)
+		}
 	}
-	opts.Language = "unknown"
+	opts := &GenerateOptions{Name: "proj", Language: "unknown", Transport: "stdio"}
 	if err := ValidateGenerateOptions(opts); err == nil {
 		t.Fatal("expected error for invalid language")
 	}

--- a/internal/handlers/test_test.go
+++ b/internal/handlers/test_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func writeConfig(t *testing.T, dir string) string {
-	cfg := &core.MCPConfig{Name: "test", Version: "0.4.2", Transport: core.Transport{Type: "stdio", Options: map[string]any{"command": "true"}}}
+	cfg := &core.MCPConfig{Name: "test", Version: "0.4.1", Transport: core.Transport{Type: "stdio", Options: map[string]any{"command": "true"}}}
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- update GenerateOptions validation to accept `rest` and `websocket`
- expand tests for new transports
- add workflow to build and verify HTTP and WebSocket servers
- sync documentation with latest tag v0.4.1

## Testing
- `go test ./...`
- `go test ./... -coverprofile=coverage.out -covermode=atomic`


------
https://chatgpt.com/codex/tasks/task_e_688ba946ab80832fa1488ecbb9856192